### PR TITLE
GDPR-29 Hooking up persistence into uploader

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/datacompliance/config/AwsRekognitionConfig.java
+++ b/src/main/java/uk/gov/justice/hmpps/datacompliance/config/AwsRekognitionConfig.java
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-public class AwsRekognitionConfiguration {
+public class AwsRekognitionConfig {
 
     @Bean
     @ConditionalOnProperty(name = "image.recognition.provider", havingValue = "aws")

--- a/src/main/java/uk/gov/justice/hmpps/datacompliance/config/DataComplianceProperties.java
+++ b/src/main/java/uk/gov/justice/hmpps/datacompliance/config/DataComplianceProperties.java
@@ -3,9 +3,11 @@ package uk.gov.justice.hmpps.datacompliance.config;
 import lombok.Getter;
 import org.hibernate.validator.constraints.URL;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.validation.annotation.Validated;
+import uk.gov.justice.hmpps.datacompliance.utils.TimeSource;
 
 @Getter
 @Validated
@@ -20,5 +22,10 @@ public class DataComplianceProperties {
                                     @Value("${elite2.api.offender.ids.page.limit:100}") final long elite2ApiOffenderIdsLimit) {
         this.elite2ApiBaseUrl = elite2ApiBaseUrl;
         this.elite2ApiOffenderIdsLimit = elite2ApiOffenderIdsLimit;
+    }
+
+    @Bean
+    public TimeSource timeSource() {
+        return TimeSource.systemUtc();
     }
 }

--- a/src/main/java/uk/gov/justice/hmpps/datacompliance/services/migration/OffenderImageMigration.java
+++ b/src/main/java/uk/gov/justice/hmpps/datacompliance/services/migration/OffenderImageMigration.java
@@ -5,33 +5,61 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import uk.gov.justice.hmpps.datacompliance.model.ImageUploadBatch;
+import uk.gov.justice.hmpps.datacompliance.repository.ImageUploadBatchRepository;
+import uk.gov.justice.hmpps.datacompliance.utils.TimeSource;
+
+import static com.microsoft.applicationinsights.agent.shadow.com.google.common.collect.Iterables.size;
 
 @Slf4j
 @Service
 @ConditionalOnProperty(name = "image.recognition.migration.cron")
-public class OffenderImageMigration {
+class OffenderImageMigration {
 
     private final OffenderIterator offenderIterator;
-    private final OffenderImageUploader offenderImageUploader;
+    private final OffenderImageUploaderFactory uploaderFactory;
+    private final ImageUploadBatchRepository repository;
+    private final TimeSource timeSource;
 
-    public OffenderImageMigration(final OffenderIterator offenderIterator,
-                                  final OffenderImageUploader offenderImageUploader,
-                                  @Value("${image.recognition.migration.cron}") final String migrationCron) {
+    OffenderImageMigration(final OffenderIterator offenderIterator,
+                           final OffenderImageUploaderFactory uploaderFactory,
+                           final ImageUploadBatchRepository repository,
+                           final TimeSource timeSource,
+                           @Value("${image.recognition.migration.cron}") final String migrationCron) {
 
         log.info("Configured to run offender image recognition migration with schedule: '{}'", migrationCron);
 
         this.offenderIterator = offenderIterator;
-        this.offenderImageUploader = offenderImageUploader;
+        this.uploaderFactory = uploaderFactory;
+        this.repository = repository;
+        this.timeSource = timeSource;
     }
 
     @Scheduled(cron = "${image.recognition.migration.cron}")
-    public void run() {
+    void run() {
 
-            log.info("Running offender image migration");
+        log.info("Running offender image migration");
 
-            offenderIterator.applyForAll(offenderImageUploader);
+        if (size(repository.findAll()) != 0) {
+            log.warn("For first proof of concept, we only need this to run once");
+            return;
+        }
 
-            log.info("Offender image migration complete");
+        final var batch = repository.save(newUploadBatch());
+        final var imageUploader = uploaderFactory.generateUploaderFor(batch);
 
+        offenderIterator.applyForAll(imageUploader);
+
+        batch.setUploadEndDateTime(timeSource.nowAsLocalDateTime());
+        batch.setUploadCount(imageUploader.getUploadCount());
+        repository.save(batch);
+
+        log.info("Offender image migration complete");
+    }
+
+    private ImageUploadBatch newUploadBatch() {
+        return ImageUploadBatch.builder()
+                .uploadStartDateTime(timeSource.nowAsLocalDateTime())
+                .build();
     }
 }

--- a/src/main/java/uk/gov/justice/hmpps/datacompliance/services/migration/OffenderImageUploadLogger.java
+++ b/src/main/java/uk/gov/justice/hmpps/datacompliance/services/migration/OffenderImageUploadLogger.java
@@ -1,0 +1,40 @@
+package uk.gov.justice.hmpps.datacompliance.services.migration;
+
+import lombok.AllArgsConstructor;
+import uk.gov.justice.hmpps.datacompliance.dto.OffenderImageMetadata;
+import uk.gov.justice.hmpps.datacompliance.dto.OffenderNumber;
+import uk.gov.justice.hmpps.datacompliance.model.ImageUploadBatch;
+import uk.gov.justice.hmpps.datacompliance.model.OffenderImageUpload;
+import uk.gov.justice.hmpps.datacompliance.repository.OffenderImageUploadRepository;
+import uk.gov.justice.hmpps.datacompliance.utils.TimeSource;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+@AllArgsConstructor
+class OffenderImageUploadLogger {
+
+    private final OffenderImageUploadRepository repository;
+    private final ImageUploadBatch uploadBatch;
+    private final TimeSource timeSource;
+    private final AtomicLong uploadCount = new AtomicLong();
+
+    void log(final OffenderNumber offenderNumber, final OffenderImageMetadata image, final String faceId) {
+        repository.save(offenderImageUpload(offenderNumber, image, faceId));
+        uploadCount.incrementAndGet();
+    }
+
+    long getUploadCount() {
+        return uploadCount.get();
+    }
+
+    private OffenderImageUpload offenderImageUpload(final OffenderNumber offenderNumber,
+                                                    final OffenderImageMetadata image, final String faceId) {
+        return OffenderImageUpload.builder()
+                .imageUploadBatch(uploadBatch)
+                .uploadDateTime(timeSource.nowAsLocalDateTime())
+                .offenderNo(offenderNumber.getOffenderNumber())
+                .imageId(image.getImageId())
+                .faceId(faceId)
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/justice/hmpps/datacompliance/services/migration/OffenderImageUploaderFactory.java
+++ b/src/main/java/uk/gov/justice/hmpps/datacompliance/services/migration/OffenderImageUploaderFactory.java
@@ -1,0 +1,24 @@
+package uk.gov.justice.hmpps.datacompliance.services.migration;
+
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import uk.gov.justice.hmpps.datacompliance.model.ImageUploadBatch;
+import uk.gov.justice.hmpps.datacompliance.repository.OffenderImageUploadRepository;
+import uk.gov.justice.hmpps.datacompliance.services.client.elite2api.Elite2ApiClient;
+import uk.gov.justice.hmpps.datacompliance.services.client.image.recognition.ImageRecognitionClient;
+import uk.gov.justice.hmpps.datacompliance.utils.TimeSource;
+
+@Service
+@AllArgsConstructor
+class OffenderImageUploaderFactory {
+
+    private final Elite2ApiClient elite2ApiClient;
+    private final ImageRecognitionClient imageRecognitionClient;
+    private final OffenderImageUploadRepository repository;
+    private final TimeSource timeSource;
+
+    OffenderImageUploader generateUploaderFor(final ImageUploadBatch batch) {
+        return new OffenderImageUploader(elite2ApiClient, imageRecognitionClient,
+                new OffenderImageUploadLogger(repository, batch, timeSource));
+    }
+}

--- a/src/main/java/uk/gov/justice/hmpps/datacompliance/services/migration/OffenderIterator.java
+++ b/src/main/java/uk/gov/justice/hmpps/datacompliance/services/migration/OffenderIterator.java
@@ -14,17 +14,17 @@ import static java.lang.Math.ceil;
 
 @Slf4j
 @Service
-public class OffenderIterator {
+class OffenderIterator {
 
     private final Elite2ApiClient elite2ApiClient;
     private final long requestLimit;
 
-    public OffenderIterator(final Elite2ApiClient elite2ApiClient, final DataComplianceProperties properties) {
+    OffenderIterator(final Elite2ApiClient elite2ApiClient, final DataComplianceProperties properties) {
         this.elite2ApiClient = elite2ApiClient;
         this.requestLimit = properties.getElite2ApiOffenderIdsLimit();
     }
 
-    public void applyForAll(final OffenderAction action) {
+    void applyForAll(final OffenderAction action) {
 
         log.info("Applying offender action to first batch of up to {} offenders", requestLimit);
         final var firstBatchResponse = applyForBatch(action, 0);
@@ -49,6 +49,6 @@ public class OffenderIterator {
         return (long) ceil((double) response.getTotalCount() / requestLimit) - 1;
     }
 
-    public interface OffenderAction extends Consumer<OffenderNumber> { }
+    interface OffenderAction extends Consumer<OffenderNumber> { }
 
 }

--- a/src/main/java/uk/gov/justice/hmpps/datacompliance/utils/TimeSource.java
+++ b/src/main/java/uk/gov/justice/hmpps/datacompliance/utils/TimeSource.java
@@ -1,0 +1,31 @@
+package uk.gov.justice.hmpps.datacompliance.utils;
+
+import java.time.*;
+
+import static java.time.ZoneOffset.UTC;
+
+public interface TimeSource {
+
+    static TimeSource systemUtc() {
+        Clock clock = Clock.systemUTC();
+        return clock::instant;
+    }
+
+    static TimeSource of(final LocalDateTime dateTime) {
+        return () -> dateTime.toInstant(UTC);
+    }
+
+    static TimeSource of(final LocalDate date) {
+        return of(date.atStartOfDay());
+    }
+
+    Instant now();
+
+    default LocalDateTime nowAsLocalDateTime() {
+        return LocalDateTime.ofInstant(now(), UTC);
+    }
+
+    default LocalDate nowAsLocalDate() {
+        return nowAsLocalDateTime().toLocalDate();
+    }
+}

--- a/src/test/java/uk/gov/justice/hmpps/datacompliance/services/migration/OffenderImageUploadLoggerTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/datacompliance/services/migration/OffenderImageUploadLoggerTest.java
@@ -1,0 +1,60 @@
+package uk.gov.justice.hmpps.datacompliance.services.migration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.hmpps.datacompliance.dto.OffenderImageMetadata;
+import uk.gov.justice.hmpps.datacompliance.dto.OffenderNumber;
+import uk.gov.justice.hmpps.datacompliance.model.ImageUploadBatch;
+import uk.gov.justice.hmpps.datacompliance.model.OffenderImageUpload;
+import uk.gov.justice.hmpps.datacompliance.repository.OffenderImageUploadRepository;
+import uk.gov.justice.hmpps.datacompliance.utils.TimeSource;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class OffenderImageUploadLoggerTest {
+
+    private static final LocalDateTime DATE_TIME = LocalDateTime.now();
+    private static final String OFFENDER_NUMBER = "offender1";
+    private static final String FACE_ID = "face1";
+    private static final long IMAGE_ID = 123L;
+
+    @Mock
+    private OffenderImageUploadRepository repository;
+
+    @Mock
+    private ImageUploadBatch batch;
+
+    private OffenderImageUploadLogger logger;
+
+    @BeforeEach
+    void setUp() {
+        logger = new OffenderImageUploadLogger(repository, batch, TimeSource.of(DATE_TIME));
+    }
+
+    @Test
+    void log() {
+
+        assertThat(logger.getUploadCount()).isZero();
+
+        logger.log(new OffenderNumber(OFFENDER_NUMBER), new OffenderImageMetadata(IMAGE_ID, "FACE"), FACE_ID);
+
+        var offenderImageUpload = ArgumentCaptor.forClass(OffenderImageUpload.class);
+        verify(repository).save(offenderImageUpload.capture());
+
+        assertThat(offenderImageUpload.getValue().getOffenderNo()).isEqualTo(OFFENDER_NUMBER);
+        assertThat(offenderImageUpload.getValue().getImageId()).isEqualTo(IMAGE_ID);
+        assertThat(offenderImageUpload.getValue().getFaceId()).isEqualTo(FACE_ID);
+        assertThat(offenderImageUpload.getValue().getUploadDateTime()).isEqualTo(DATE_TIME);
+        assertThat(offenderImageUpload.getValue().getImageUploadBatch()).isEqualTo(batch);
+
+        assertThat(logger.getUploadCount()).isEqualTo(1);
+    }
+}

--- a/src/test/java/uk/gov/justice/hmpps/datacompliance/services/migration/OffenderImageUploaderTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/datacompliance/services/migration/OffenderImageUploaderTest.java
@@ -10,10 +10,12 @@ import uk.gov.justice.hmpps.datacompliance.dto.OffenderNumber;
 import uk.gov.justice.hmpps.datacompliance.services.client.elite2api.Elite2ApiClient;
 import uk.gov.justice.hmpps.datacompliance.services.client.image.recognition.ImageRecognitionClient;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static java.util.Collections.emptyList;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class OffenderImageUploaderTest {
@@ -21,6 +23,7 @@ class OffenderImageUploaderTest {
     private static final OffenderNumber OFFENDER_NUMBER = new OffenderNumber("offender1");
     private static final long IMAGE_ID = 123L;
     private static final byte[] IMAGE_DATA = new byte[]{0x12};
+    private static final OffenderImageMetadata IMAGE_METADATA = new OffenderImageMetadata(IMAGE_ID, "FACE");
 
     @Mock
     private Elite2ApiClient elite2ApiClient;
@@ -28,28 +31,58 @@ class OffenderImageUploaderTest {
     @Mock
     private ImageRecognitionClient imageRecognitionClient;
 
+    @Mock
+    private OffenderImageUploadLogger logger;
+
     private OffenderImageUploader imageUploader;
 
     @BeforeEach
     void setUp() {
-        imageUploader = new OffenderImageUploader(elite2ApiClient, imageRecognitionClient);
+        imageUploader = new OffenderImageUploader(elite2ApiClient, imageRecognitionClient, logger);
     }
 
     @Test
     void uploadOffenderImages() {
 
         when(elite2ApiClient.getOffenderFaceImagesFor(OFFENDER_NUMBER))
-                .thenReturn(List.of(new OffenderImageMetadata(IMAGE_ID, "FACE")));
+                .thenReturn(List.of(IMAGE_METADATA));
 
         when(elite2ApiClient.getImageData(IMAGE_ID)).thenReturn(IMAGE_DATA);
 
+        when(imageRecognitionClient.uploadImageToCollection(IMAGE_DATA, OFFENDER_NUMBER, IMAGE_ID))
+                .thenReturn(Optional.of("face1"));
+
         imageUploader.accept(OFFENDER_NUMBER);
 
-        verify(imageRecognitionClient).uploadImageToCollection(IMAGE_DATA, OFFENDER_NUMBER, IMAGE_ID);
+        verify(logger).log(OFFENDER_NUMBER, IMAGE_METADATA, "face1");
     }
 
     @Test
-    void name() {
+    void uploadOffenderImagesHandlesNoImages() {
 
+        when(elite2ApiClient.getOffenderFaceImagesFor(OFFENDER_NUMBER))
+                .thenReturn(emptyList());
+
+        imageUploader.accept(OFFENDER_NUMBER);
+
+        verifyNoInteractions(imageRecognitionClient);
+        verifyNoInteractions(logger);
     }
+
+    @Test
+    void uploadMayResultInNoIndexedFaces() {
+
+        when(elite2ApiClient.getOffenderFaceImagesFor(OFFENDER_NUMBER))
+                .thenReturn(List.of(IMAGE_METADATA));
+
+        when(elite2ApiClient.getImageData(IMAGE_ID)).thenReturn(IMAGE_DATA);
+
+        when(imageRecognitionClient.uploadImageToCollection(IMAGE_DATA, OFFENDER_NUMBER, IMAGE_ID))
+                .thenReturn(Optional.empty());
+
+        imageUploader.accept(OFFENDER_NUMBER);
+
+        verifyNoInteractions(logger);
+    }
+
 }

--- a/src/test/java/uk/gov/justice/hmpps/datacompliance/utils/TimeSourceTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/datacompliance/utils/TimeSourceTest.java
@@ -1,0 +1,19 @@
+package uk.gov.justice.hmpps.datacompliance.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static java.time.LocalDate.EPOCH;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TimeSourceTest {
+
+    @Test
+    void timeSourceCanBeSet() {
+
+        var source = TimeSource.of(EPOCH);
+
+        assertThat(source.now().toEpochMilli()).isZero();
+        assertThat(source.nowAsLocalDate()).isEqualTo(EPOCH);
+        assertThat(source.nowAsLocalDateTime()).isEqualTo(EPOCH.atStartOfDay());
+    }
+}


### PR DESCRIPTION
This enables us to log when the upload process begins and ends and to record details about every indexed face derived from an offender image.