### PR TITLE
GDPR-41 Adding listener for pending deletion queue

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/datacompliance/services/events/dto/OffenderPendingDeletionEvent.java
+++ b/src/main/java/uk/gov/justice/hmpps/datacompliance/services/events/dto/OffenderPendingDeletionEvent.java
@@ -1,0 +1,13 @@
+package uk.gov.justice.hmpps.datacompliance.services.events.dto;
+
+import lombok.*;
+
+@Getter
+@ToString
+@EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor
+public class OffenderPendingDeletionEvent {
+    private String offenderIdDisplay;
+}
+

--- a/src/main/java/uk/gov/justice/hmpps/datacompliance/services/events/listeners/OffenderPendingDeletionListener.java
+++ b/src/main/java/uk/gov/justice/hmpps/datacompliance/services/events/listeners/OffenderPendingDeletionListener.java
@@ -1,0 +1,81 @@
+package uk.gov.justice.hmpps.datacompliance.services.events.listeners;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.jms.annotation.JmsListener;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.stereotype.Service;
+import uk.gov.justice.hmpps.datacompliance.services.events.dto.OffenderPendingDeletionEvent;
+
+import java.io.IOException;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+import static org.apache.commons.lang3.ObjectUtils.isNotEmpty;
+
+@Slf4j
+@Service
+@ConditionalOnExpression("{'aws', 'localstack'}.contains('${inbound.referral.sqs.provider}')")
+public class OffenderPendingDeletionListener {
+
+    private static final String OFFENDER_PENDING_DELETION_EVENT = "DATA_COMPLIANCE_OFFENDER-PENDING-DELETION";
+    private static final String OFFENDER_PENDING_DELETION_COMPLETE_EVENT = "DATA_COMPLIANCE_OFFENDER-PENDING-DELETION-COMPLETE";
+    private static final List<String> EXPECTED_EVENT_TYPES = List.of(
+            OFFENDER_PENDING_DELETION_EVENT,
+            OFFENDER_PENDING_DELETION_COMPLETE_EVENT);
+
+    private final ObjectMapper objectMapper;
+
+    public OffenderPendingDeletionListener(final ObjectMapper objectMapper) {
+
+        log.info("Configured to listen to Offender Pending Deletion events");
+
+        this.objectMapper = objectMapper;
+    }
+
+    @JmsListener(destination = "${inbound.referral.sqs.queue.name}")
+    public void handleOffenderPendingDeletionReferral(final Message<String> message) {
+
+        log.debug("Handling incoming offender pending deletion referral: {}", message);
+
+        final var eventType = getEventType(message.getHeaders());
+
+        if (OFFENDER_PENDING_DELETION_EVENT.equals(eventType)) {
+            // TODO GDPR-51 Implement pipeline of offender checks
+            log.warn("Not yet implemented pipeline of offender checks, ignoring referral for offender: '{}'",
+                    getOffenderIdDisplay(message.getPayload()));
+        }
+    }
+
+    private String getEventType(final MessageHeaders messageHeaders) {
+
+        final var eventType = (String) messageHeaders.get("eventType");
+
+        checkNotNull(eventType, "Message event type not found");
+        checkState(EXPECTED_EVENT_TYPES.contains(eventType),
+                "Unexpected message event type: '%s', expecting one of: %s", eventType, EXPECTED_EVENT_TYPES);
+
+        return eventType;
+    }
+
+    private String getOffenderIdDisplay(final String messageBody) {
+
+        final OffenderPendingDeletionEvent event = parseOffenderPendingDeletionEvent(messageBody);
+
+        checkState(isNotEmpty(event.getOffenderIdDisplay()), "No offender specified in request: %s", messageBody);
+
+        return event.getOffenderIdDisplay();
+    }
+
+    private OffenderPendingDeletionEvent parseOffenderPendingDeletionEvent(final String requestJson) {
+        try {
+            return objectMapper.readValue(requestJson, OffenderPendingDeletionEvent.class);
+
+        } catch (final IOException e) {
+            throw new RuntimeException("Failed to parse request: " + requestJson, e);
+        }
+    }
+}

--- a/src/test/java/uk/gov/justice/hmpps/datacompliance/services/events/listeners/OffenderPendingDeletionListenerTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/datacompliance/services/events/listeners/OffenderPendingDeletionListenerTest.java
@@ -1,0 +1,72 @@
+package uk.gov.justice.hmpps.datacompliance.services.events.listeners;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OffenderPendingDeletionListenerTest {
+
+    private OffenderPendingDeletionListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new OffenderPendingDeletionListener(new ObjectMapper());
+    }
+
+    @Test
+    void handleOffenderDeletionEventThrowsIfMessageAttributesNotPresent() {
+        assertThatThrownBy(() -> handleMessage("{\"offenderIdDisplay\":\"A1234AA\"}", Map.of()))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("Message event type not found");
+    }
+
+    @Test
+    void handleOffenderDeletionEventThrowsIfEventTypeUnexpected() {
+        assertThatThrownBy(() -> handleMessage("{\"offenderIdDisplay\":\"A1234AA\"}", Map.of("eventType", "UNEXPECTED!")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Unexpected message event type: 'UNEXPECTED!', expecting one of: [DATA_COMPLIANCE_OFFENDER-PENDING-DELETION, DATA_COMPLIANCE_OFFENDER-PENDING-DELETION-COMPLETE]");
+    }
+
+    @Test
+    void handleOffenderDeletionEventThrowsIfMessageNotPresent() {
+        assertThatThrownBy(() -> handleMessage(null, Map.of("eventType", "DATA_COMPLIANCE_OFFENDER-PENDING-DELETION")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("argument \"content\" is null");
+    }
+
+    @Test
+    void handleOffenderDeletionEventThrowsIfMessageUnparsable() {
+        assertThatThrownBy(() -> handleMessage("BAD MESSAGE!", Map.of("eventType", "DATA_COMPLIANCE_OFFENDER-PENDING-DELETION")))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Failed to parse request");
+    }
+
+    @Test
+    void handleOffenderDeletionEventThrowsIfOffenderIdDisplayEmpty() {
+        assertThatThrownBy(() -> handleMessage("{\"offenderIdDisplay\":\"\"}", Map.of("eventType", "DATA_COMPLIANCE_OFFENDER-PENDING-DELETION")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("No offender specified in request");
+    }
+
+    private void handleMessage(final String payload, final Map<String, Object> headers) {
+        listener.handleOffenderPendingDeletionReferral(mockMessage(payload, headers));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Message<String> mockMessage(final String payload, final Map<String, Object> headers) {
+        final var message = mock(Message.class);
+        when(message.getHeaders()).thenReturn(new MessageHeaders(headers));
+        lenient().when(message.getPayload()).thenReturn(payload);
+        return message;
+    }
+}


### PR DESCRIPTION
Currently doesn't really do anything upon reception of the event, but eventually will start a pipeline of checks on the offender