### PR TITLE
GDPR-88 Adding SNS client to push deletion completed events

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,12 +91,14 @@ dependencies {
     implementation platform('software.amazon.awssdk:bom:2.10.68')
     implementation 'software.amazon.awssdk:rekognition'
 
-    implementation platform('com.amazonaws:aws-java-sdk-bom:1.11.722')
+    implementation platform('com.amazonaws:aws-java-sdk-bom:1.11.730')
+    implementation 'com.amazonaws:aws-java-sdk-sns:1.11.730'
     implementation 'com.amazonaws:amazon-sqs-java-messaging-lib:1.0.8'
 
     // Utils
     implementation 'com.google.guava:guava:28.2-jre'
     implementation 'org.apache.commons:commons-lang3:3.9'
+    implementation 'commons-io:commons-io:2.6'
     implementation ('org.quartz-scheduler:quartz:2.3.2') {
         exclude group: 'com.zaxxer'
     }

--- a/helm_deploy/dps-data-compliance/templates/_envs.tpl
+++ b/helm_deploy/dps-data-compliance/templates/_envs.tpl
@@ -10,9 +10,6 @@ env:
   - name: JAVA_OPTS
     value: "{{ .Values.env.JAVA_OPTS }}"
 
-  - name: SPRING_PROFILES_ACTIVE
-    value: "sns"
-
   - name: ELITE2_API_BASE_URL
     value: "{{ .Values.env.ELITE2_API_BASE_URL }}"
 

--- a/src/main/java/uk/gov/justice/hmpps/datacompliance/config/OffenderDeletionCompletedSnsConfig.java
+++ b/src/main/java/uk/gov/justice/hmpps/datacompliance/config/OffenderDeletionCompletedSnsConfig.java
@@ -1,0 +1,47 @@
+package uk.gov.justice.hmpps.datacompliance.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
+import com.amazonaws.services.sns.AmazonSNS;
+import com.amazonaws.services.sns.AmazonSNSAsyncClientBuilder;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j
+@Configuration
+@ConditionalOnExpression("{'aws', 'localstack'}.contains('${sns.provider}')")
+public class OffenderDeletionCompletedSnsConfig {
+
+    @Bean
+    @ConditionalOnProperty(name = "sns.provider", havingValue = "aws")
+    public AmazonSNS awsSnsClient(@Value("${sns.aws.access.key.id}") final String accessKeyId,
+                                  @Value("${sns.aws.secret.access.key}") final String secretAccessKey,
+                                  @Value("${sns.region}") final String region) {
+
+        log.info("Creating SNS Client");
+
+        final var credentials = new BasicAWSCredentials(accessKeyId, secretAccessKey);
+
+        return AmazonSNSAsyncClientBuilder.standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(region)
+                .build();
+    }
+
+    @Bean("awsSnsClient")
+    @ConditionalOnProperty(name = "sns.provider", havingValue = "localstack", matchIfMissing = true)
+    public AmazonSNS awsSnsClientLocalStack(@Value("${sns.endpoint.url}") final String serviceEndpoint,
+                                            @Value("${sns.region}") final String region) {
+
+        log.info("Creating LocalStack SNS Client");
+
+        return AmazonSNSAsyncClientBuilder.standard()
+                .withEndpointConfiguration(new EndpointConfiguration(serviceEndpoint, region))
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/justice/hmpps/datacompliance/services/events/dto/OffenderDeletionCompleteEvent.java
+++ b/src/main/java/uk/gov/justice/hmpps/datacompliance/services/events/dto/OffenderDeletionCompleteEvent.java
@@ -1,0 +1,56 @@
+package uk.gov.justice.hmpps.datacompliance.services.events.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+import java.util.List;
+
+/**
+ * This event signifies that an offender
+ * has been successfully deleted in NOMIS
+ * and that downstream services should handle
+ * appropriately.
+ */
+@Getter
+@Builder
+@ToString
+@EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor
+public class OffenderDeletionCompleteEvent {
+
+    @JsonProperty("offenderIdDisplay")
+    private String offenderIdDisplay;
+
+    @Singular
+    @JsonProperty("offenders")
+    private List<OffenderWithBookings> offenders;
+
+    @Getter
+    @Builder
+    @ToString
+    @EqualsAndHashCode
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class OffenderWithBookings {
+
+        @JsonProperty("offenderId")
+        private Long offenderId;
+
+        @Singular
+        @JsonProperty("bookings")
+        private List<Booking> bookings;
+    }
+
+    @Getter
+    @ToString
+    @EqualsAndHashCode
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Booking {
+
+        @JsonProperty("offenderBookId")
+        private Long offenderBookId;
+    }
+}
+

--- a/src/main/java/uk/gov/justice/hmpps/datacompliance/services/events/publishers/deletion/completed/OffenderDeletionCompleteAwsEventPusher.java
+++ b/src/main/java/uk/gov/justice/hmpps/datacompliance/services/events/publishers/deletion/completed/OffenderDeletionCompleteAwsEventPusher.java
@@ -1,0 +1,60 @@
+package uk.gov.justice.hmpps.datacompliance.services.events.publishers.deletion.completed;
+
+import com.amazonaws.services.sns.AmazonSNS;
+import com.amazonaws.services.sns.model.MessageAttributeValue;
+import com.amazonaws.services.sns.model.PublishRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.stereotype.Component;
+import uk.gov.justice.hmpps.datacompliance.services.events.dto.OffenderDeletionCompleteEvent;
+
+import java.util.Map;
+
+@Slf4j
+@Component
+@ConditionalOnExpression("{'aws', 'localstack'}.contains('${sns.provider}')")
+public class OffenderDeletionCompleteAwsEventPusher implements OffenderDeletionCompleteEventPusher {
+
+    private final AmazonSNS amazonSns;
+    private final String topicArn;
+    private final ObjectMapper objectMapper;
+
+    public OffenderDeletionCompleteAwsEventPusher(@Qualifier("awsSnsClient") final AmazonSNS amazonSns,
+                                                  @Value("${sns.topic.arn}") final String topicArn,
+                                                  final ObjectMapper objectMapper) {
+        this.topicArn = topicArn;
+        this.amazonSns = amazonSns;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void sendEvent(final OffenderDeletionCompleteEvent event) {
+        amazonSns.publish(generateRequest(event));
+    }
+
+    private PublishRequest generateRequest(final OffenderDeletionCompleteEvent event) {
+        return new PublishRequest()
+                .withTopicArn(topicArn)
+                .withMessageAttributes(Map.of(
+                        "eventType", stringAttribute("DATA_COMPLIANCE_DELETE-OFFENDER"),
+                        "contentType", stringAttribute("text/plain;charset=UTF-8")))
+                .withMessage(toJson(event));
+    }
+
+    private MessageAttributeValue stringAttribute(final String value) {
+        return new MessageAttributeValue()
+                .withDataType("String")
+                .withStringValue(value);
+    }
+
+    private String toJson(final OffenderDeletionCompleteEvent event) {
+        try {
+            return objectMapper.writeValueAsString(event);
+        } catch (final Exception e) {
+            throw new RuntimeException("Failed to serialise offender deletion complete event", e);
+        }
+    }
+}

--- a/src/main/java/uk/gov/justice/hmpps/datacompliance/services/events/publishers/deletion/completed/OffenderDeletionCompleteEventPusher.java
+++ b/src/main/java/uk/gov/justice/hmpps/datacompliance/services/events/publishers/deletion/completed/OffenderDeletionCompleteEventPusher.java
@@ -1,0 +1,7 @@
+package uk.gov.justice.hmpps.datacompliance.services.events.publishers.deletion.completed;
+
+import uk.gov.justice.hmpps.datacompliance.services.events.dto.OffenderDeletionCompleteEvent;
+
+public interface OffenderDeletionCompleteEventPusher {
+    void sendEvent(OffenderDeletionCompleteEvent event);
+}

--- a/src/main/java/uk/gov/justice/hmpps/datacompliance/services/events/publishers/deletion/completed/OffenderDeletionCompleteNoOpEventPusher.java
+++ b/src/main/java/uk/gov/justice/hmpps/datacompliance/services/events/publishers/deletion/completed/OffenderDeletionCompleteNoOpEventPusher.java
@@ -1,0 +1,21 @@
+package uk.gov.justice.hmpps.datacompliance.services.events.publishers.deletion.completed;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.stereotype.Component;
+import uk.gov.justice.hmpps.datacompliance.services.events.dto.OffenderDeletionCompleteEvent;
+
+@Slf4j
+@Component
+@ConditionalOnExpression("!{'aws', 'localstack'}.contains('${sns.provider}')")
+public class OffenderDeletionCompleteNoOpEventPusher implements OffenderDeletionCompleteEventPusher {
+
+    public OffenderDeletionCompleteNoOpEventPusher() {
+        log.info("Configured to ignore offender deletion complete events");
+    }
+
+    @Override
+    public void sendEvent(final OffenderDeletionCompleteEvent event) {
+        log.warn("Pretending to push offender deletion completed event for '{}' to queue", event.getOffenderIdDisplay());
+    }
+}

--- a/src/main/java/uk/gov/justice/hmpps/datacompliance/services/events/publishers/deletion/granted/OffenderDeletionGrantedAwsEventPusher.java
+++ b/src/main/java/uk/gov/justice/hmpps/datacompliance/services/events/publishers/deletion/granted/OffenderDeletionGrantedAwsEventPusher.java
@@ -1,4 +1,4 @@
-package uk.gov.justice.hmpps.datacompliance.services.events.publishers;
+package uk.gov.justice.hmpps.datacompliance.services.events.publishers.deletion.granted;
 
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.model.MessageAttributeValue;

--- a/src/main/java/uk/gov/justice/hmpps/datacompliance/services/events/publishers/deletion/granted/OffenderDeletionGrantedEventPusher.java
+++ b/src/main/java/uk/gov/justice/hmpps/datacompliance/services/events/publishers/deletion/granted/OffenderDeletionGrantedEventPusher.java
@@ -1,4 +1,4 @@
-package uk.gov.justice.hmpps.datacompliance.services.events.publishers;
+package uk.gov.justice.hmpps.datacompliance.services.events.publishers.deletion.granted;
 
 public interface OffenderDeletionGrantedEventPusher {
     void sendEvent(final String offenderIdDisplay);

--- a/src/main/java/uk/gov/justice/hmpps/datacompliance/services/events/publishers/deletion/granted/OffenderDeletionGrantedNoOpEventPusher.java
+++ b/src/main/java/uk/gov/justice/hmpps/datacompliance/services/events/publishers/deletion/granted/OffenderDeletionGrantedNoOpEventPusher.java
@@ -1,4 +1,4 @@
-package uk.gov.justice.hmpps.datacompliance.services.events.publishers;
+package uk.gov.justice.hmpps.datacompliance.services.events.publishers.deletion.granted;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;

--- a/src/main/resources/application-localstack.yml
+++ b/src/main/resources/application-localstack.yml
@@ -12,3 +12,9 @@ inbound.referral:
     queue.name: inbound_referral_queue
     dlq.name: inbound_referral_dead_letter_queue
     endpoint.url: http://localstack:4576
+
+sns:
+  provider: localstack
+  topic.arn: arn:aws:sns:eu-west-2:000000000000:offender_events
+  endpoint.url: http://localstack:4575
+  region: eu-west-2

--- a/src/test/java/uk/gov/justice/hmpps/datacompliance/services/events/publishers/deletion/completed/OffenderDeletionCompleteEventPusherTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/datacompliance/services/events/publishers/deletion/completed/OffenderDeletionCompleteEventPusherTest.java
@@ -1,0 +1,82 @@
+package uk.gov.justice.hmpps.datacompliance.services.events.publishers.deletion.completed;
+
+import com.amazonaws.services.sns.AmazonSNS;
+import com.amazonaws.services.sns.model.PublishRequest;
+import com.amazonaws.services.sns.model.PublishResult;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.hmpps.datacompliance.services.events.dto.OffenderDeletionCompleteEvent;
+import uk.gov.justice.hmpps.datacompliance.services.events.dto.OffenderDeletionCompleteEvent.Booking;
+import uk.gov.justice.hmpps.datacompliance.services.events.dto.OffenderDeletionCompleteEvent.OffenderWithBookings;
+
+import java.io.IOException;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OffenderDeletionCompleteEventPusherTest {
+
+    private final static ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Mock
+    private AmazonSNS client;
+
+    private OffenderDeletionCompleteEventPusher eventPusher;
+
+    @BeforeEach
+    void setUp() {
+        eventPusher = new OffenderDeletionCompleteAwsEventPusher(client, "topic.arn", OBJECT_MAPPER);
+    }
+
+    @Test
+    void sendEvent() throws Exception {
+
+        final var request = ArgumentCaptor.forClass(PublishRequest.class);
+        when(client.publish(request.capture()))
+                .thenReturn(new PublishResult().withMessageId("messageId"));
+
+        eventPusher.sendEvent(deletionCompleteEvent());
+
+        assertThat(request.getValue().getMessage()).isEqualToIgnoringWhitespace(getJson("delete-offender-event.json"));
+        assertThat(request.getValue().getTopicArn()).isEqualTo("topic.arn");
+        assertThat(request.getValue().getMessageAttributes().get("eventType").getStringValue())
+                .isEqualTo("DATA_COMPLIANCE_DELETE-OFFENDER");
+    }
+
+    @Test
+    void sendEventPropagatesException() {
+        when(client.publish(any())).thenThrow(RuntimeException.class);
+        assertThatThrownBy(() -> eventPusher.sendEvent(any())).isInstanceOf(RuntimeException.class);
+    }
+
+    private OffenderDeletionCompleteEvent deletionCompleteEvent() {
+        return OffenderDeletionCompleteEvent.builder()
+                .offenderIdDisplay("offender1")
+                .offender(OffenderWithBookings.builder()
+                        .offenderId(1L)
+                        .booking(new Booking(11L))
+                        .booking(new Booking(12L))
+                        .build())
+                .offender(OffenderWithBookings.builder()
+                        .offenderId(2L)
+                        .booking(new Booking(21L))
+                        .booking(new Booking(22L))
+                        .build())
+                .build();
+    }
+
+    private String getJson(final String filename) throws IOException {
+        return IOUtils.toString(this.getClass().getResource(filename).openStream(), UTF_8);
+    }
+}
+

--- a/src/test/java/uk/gov/justice/hmpps/datacompliance/services/events/publishers/deletion/granted/OffenderDeletionGrantedEventPusherTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/datacompliance/services/events/publishers/deletion/granted/OffenderDeletionGrantedEventPusherTest.java
@@ -1,4 +1,4 @@
-package uk.gov.justice.hmpps.datacompliance.services.events.publishers;
+package uk.gov.justice.hmpps.datacompliance.services.events.publishers.deletion.granted;
 
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.model.SendMessageRequest;
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.hmpps.datacompliance.services.events.publishers.deletion.granted.OffenderDeletionGrantedAwsEventPusher;
+import uk.gov.justice.hmpps.datacompliance.services.events.publishers.deletion.granted.OffenderDeletionGrantedEventPusher;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/src/test/resources/uk/gov/justice/hmpps/datacompliance/services/events/publishers/deletion/completed/delete-offender-event.json
+++ b/src/test/resources/uk/gov/justice/hmpps/datacompliance/services/events/publishers/deletion/completed/delete-offender-event.json
@@ -1,0 +1,19 @@
+{
+  "offenderIdDisplay": "offender1",
+  "offenders": [
+    {
+      "offenderId": 1,
+      "bookings": [
+        {"offenderBookId": 11},
+        {"offenderBookId": 12}
+      ]
+    },
+    {
+      "offenderId": 2,
+      "bookings": [
+        {"offenderBookId":21},
+        {"offenderBookId":22}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This will allow the Data Compliance Service to publish an event
indicating that other services may now go ahead and delete their
data now the data in NOMIS has successfully been deleted.