### PR TITLE
GDPR-111 Implementing pending data duplication check

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/datacompliance/repository/jpa/model/retention/RetentionCheck.java
+++ b/src/main/java/uk/gov/justice/hmpps/datacompliance/repository/jpa/model/retention/RetentionCheck.java
@@ -22,7 +22,6 @@ import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
 
 import static javax.persistence.FetchType.LAZY;
-import static uk.gov.justice.hmpps.datacompliance.repository.jpa.model.retention.RetentionCheck.Status.PENDING;
 
 @Data
 @Entity
@@ -60,11 +59,4 @@ public abstract class RetentionCheck {
     @Column(name = "CHECK_STATUS", nullable = false)
     private RetentionCheck.Status checkStatus;
 
-    public boolean isComplete() {
-        return checkStatus != null && checkStatus != PENDING;
-    }
-
-    public boolean isStatus(final Status value) {
-        return checkStatus != null && checkStatus == value;
-    }
 }

--- a/src/main/java/uk/gov/justice/hmpps/datacompliance/repository/jpa/model/retention/RetentionCheckDataDuplicate.java
+++ b/src/main/java/uk/gov/justice/hmpps/datacompliance/repository/jpa/model/retention/RetentionCheckDataDuplicate.java
@@ -25,20 +25,20 @@ import static javax.persistence.CascadeType.PERSIST;
 import static javax.persistence.FetchType.LAZY;
 
 @Entity
-@DiscriminatorValue(RetentionCheckDataDuplicate.DUPLICATE)
+@DiscriminatorValue(RetentionCheckDataDuplicate.DATA_DUPLICATE)
 public class RetentionCheckDataDuplicate extends RetentionCheck {
 
-    public static final String DUPLICATE = "DATA_DUPLICATE";
+    public static final String DATA_DUPLICATE = "DATA_DUPLICATE";
 
     @OneToMany(mappedBy = "retentionCheck", cascade = PERSIST, fetch = LAZY)
     private final List<RetentionReasonDataDuplicate> dataDuplicates = new ArrayList<>();
 
-    public RetentionCheckDataDuplicate() {
+    private RetentionCheckDataDuplicate() {
         this(null);
     }
 
     public RetentionCheckDataDuplicate(final Status status) {
-        super(null, null, DUPLICATE, status);
+        super(null, null, DATA_DUPLICATE, status);
     }
 
     public RetentionCheckDataDuplicate addDataDuplicates(final List<DataDuplicate> dataDuplicates) {

--- a/src/main/java/uk/gov/justice/hmpps/datacompliance/repository/jpa/model/retention/RetentionCheckImageDuplicate.java
+++ b/src/main/java/uk/gov/justice/hmpps/datacompliance/repository/jpa/model/retention/RetentionCheckImageDuplicate.java
@@ -34,7 +34,7 @@ public class RetentionCheckImageDuplicate extends RetentionCheck {
     @OneToMany(mappedBy = "retentionCheck", cascade = PERSIST, fetch = LAZY)
     private final List<RetentionReasonImageDuplicate> imageDuplicates = new ArrayList<>();
 
-    public RetentionCheckImageDuplicate() {
+    private RetentionCheckImageDuplicate() {
         this(null);
     }
 

--- a/src/main/java/uk/gov/justice/hmpps/datacompliance/repository/jpa/model/retention/RetentionCheckManual.java
+++ b/src/main/java/uk/gov/justice/hmpps/datacompliance/repository/jpa/model/retention/RetentionCheckManual.java
@@ -31,7 +31,7 @@ public class RetentionCheckManual extends RetentionCheck {
     @OneToOne(mappedBy = "retentionCheck", cascade = PERSIST, fetch = LAZY)
     private RetentionReasonManual retentionReasonManual;
 
-    public RetentionCheckManual() {
+    private RetentionCheckManual() {
         this(null);
     }
 

--- a/src/main/java/uk/gov/justice/hmpps/datacompliance/repository/jpa/model/retention/RetentionCheckPathfinder.java
+++ b/src/main/java/uk/gov/justice/hmpps/datacompliance/repository/jpa/model/retention/RetentionCheckPathfinder.java
@@ -9,7 +9,7 @@ public class RetentionCheckPathfinder extends RetentionCheck {
 
     public static final String PATHFINDER_REFERRAL = "PATHFINDER_REFERRAL";
 
-    public RetentionCheckPathfinder() {
+    private RetentionCheckPathfinder() {
         this(null);
     }
 

--- a/src/main/java/uk/gov/justice/hmpps/datacompliance/services/duplicate/detection/data/DataDuplicationDetectionService.java
+++ b/src/main/java/uk/gov/justice/hmpps/datacompliance/services/duplicate/detection/data/DataDuplicationDetectionService.java
@@ -3,17 +3,11 @@ package uk.gov.justice.hmpps.datacompliance.services.duplicate.detection.data;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import uk.gov.justice.hmpps.datacompliance.dto.OffenderNumber;
-import uk.gov.justice.hmpps.datacompliance.repository.jpa.model.duplication.DataDuplicate;
-
-import java.util.List;
-
-import static java.util.Collections.emptyList;
 
 @Service
 @AllArgsConstructor
 public class DataDuplicationDetectionService {
-    public List<DataDuplicate> findDuplicatesFor(final OffenderNumber offenderNumber) {
-        // TODO GDPR-111 Implement duplicate data detection check
-        return emptyList();
+    public void searchForDuplicates(final OffenderNumber offenderNumber, final Long checkId) {
+        // TODO GDPR-111 Implement asynchronous duplicate data detection check
     }
 }

--- a/src/main/java/uk/gov/justice/hmpps/datacompliance/services/retention/ActionableRetentionCheck.java
+++ b/src/main/java/uk/gov/justice/hmpps/datacompliance/services/retention/ActionableRetentionCheck.java
@@ -1,0 +1,47 @@
+package uk.gov.justice.hmpps.datacompliance.services.retention;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import uk.gov.justice.hmpps.datacompliance.repository.jpa.model.retention.RetentionCheck;
+import uk.gov.justice.hmpps.datacompliance.repository.jpa.model.retention.RetentionCheck.Status;
+
+import static uk.gov.justice.hmpps.datacompliance.repository.jpa.model.retention.RetentionCheck.Status.PENDING;
+
+/**
+ * A wrapper class for the RetentionCheck,
+ * allowing a process to be triggered once
+ * database entities have been persisted and
+ * generated ids are made available.
+ */
+@RequiredArgsConstructor
+public class ActionableRetentionCheck {
+
+    @Getter
+    private final RetentionCheck retentionCheck;
+
+    private PendingCheck pendingCheck;
+
+    public ActionableRetentionCheck setPendingCheck(final PendingCheck pendingCheck) {
+        this.pendingCheck = pendingCheck;
+        return this;
+    }
+
+    public void triggerPendingCheck() {
+        if (pendingCheck != null) {
+            pendingCheck.triggerCheck(retentionCheck);
+        }
+    }
+
+    public boolean isPending() {
+        return retentionCheck.getCheckStatus() != null && retentionCheck.getCheckStatus() == PENDING;
+    }
+
+    public boolean isStatus(final Status value) {
+        return retentionCheck.getCheckStatus() != null && retentionCheck.getCheckStatus() == value;
+    }
+
+    @FunctionalInterface
+    public interface PendingCheck {
+        void triggerCheck(RetentionCheck retentionCheck);
+    }
+}

--- a/src/main/java/uk/gov/justice/hmpps/datacompliance/services/retention/RetentionService.java
+++ b/src/main/java/uk/gov/justice/hmpps/datacompliance/services/retention/RetentionService.java
@@ -5,14 +5,16 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.gov.justice.hmpps.datacompliance.client.pathfinder.PathfinderApiClient;
 import uk.gov.justice.hmpps.datacompliance.dto.OffenderNumber;
-import uk.gov.justice.hmpps.datacompliance.repository.jpa.model.retention.RetentionCheck;
+import uk.gov.justice.hmpps.datacompliance.repository.jpa.model.retention.RetentionCheckDataDuplicate;
 import uk.gov.justice.hmpps.datacompliance.repository.jpa.model.retention.RetentionCheckImageDuplicate;
 import uk.gov.justice.hmpps.datacompliance.repository.jpa.model.retention.RetentionCheckManual;
 import uk.gov.justice.hmpps.datacompliance.repository.jpa.model.retention.RetentionCheckPathfinder;
+import uk.gov.justice.hmpps.datacompliance.services.duplicate.detection.data.DataDuplicationDetectionService;
 import uk.gov.justice.hmpps.datacompliance.services.duplicate.detection.image.ImageDuplicationDetectionService;
 
 import java.util.List;
 
+import static uk.gov.justice.hmpps.datacompliance.repository.jpa.model.retention.RetentionCheck.Status.PENDING;
 import static uk.gov.justice.hmpps.datacompliance.repository.jpa.model.retention.RetentionCheck.Status.RETENTION_NOT_REQUIRED;
 import static uk.gov.justice.hmpps.datacompliance.repository.jpa.model.retention.RetentionCheck.Status.RETENTION_REQUIRED;
 
@@ -24,36 +26,51 @@ public class RetentionService {
     private final PathfinderApiClient pathfinderApiClient;
     private final ManualRetentionService manualRetentionService;
     private final ImageDuplicationDetectionService imageDuplicationDetectionService;
+    private final DataDuplicationDetectionService dataDuplicationDetectionService;
 
-    public List<RetentionCheck> conductRetentionChecks(final OffenderNumber offenderNumber) {
+    public List<ActionableRetentionCheck> conductRetentionChecks(final OffenderNumber offenderNumber) {
 
         // TODO GDPR-112 complete the following checks
-        //  * Data duplicate check
         //  * Moratoria
 
         return List.of(
                 pathfinderReferralCheck(offenderNumber),
                 manualRetentionCheck(offenderNumber),
-                imageDuplicateCheck(offenderNumber));
+                imageDuplicateCheck(offenderNumber),
+                dataDuplicateCheck(offenderNumber));
     }
 
-    private RetentionCheck pathfinderReferralCheck(final OffenderNumber offenderNumber) {
-        return new RetentionCheckPathfinder(pathfinderApiClient.isReferredToPathfinder(offenderNumber) ?
+    private ActionableRetentionCheck pathfinderReferralCheck(final OffenderNumber offenderNumber) {
+
+        final var check = new RetentionCheckPathfinder(pathfinderApiClient.isReferredToPathfinder(offenderNumber) ?
                 RETENTION_REQUIRED : RETENTION_NOT_REQUIRED);
+
+        return new ActionableRetentionCheck(check);
     }
 
-    private RetentionCheck manualRetentionCheck(final OffenderNumber offenderNumber) {
-        return manualRetentionService.findManualOffenderRetentionWithReasons(offenderNumber)
+    private ActionableRetentionCheck manualRetentionCheck(final OffenderNumber offenderNumber) {
+
+        final var check = manualRetentionService.findManualOffenderRetentionWithReasons(offenderNumber)
                 .map(manualRetention -> new RetentionCheckManual(RETENTION_REQUIRED).setManualRetention(manualRetention))
                 .orElseGet(() -> new RetentionCheckManual(RETENTION_NOT_REQUIRED));
+
+        return new ActionableRetentionCheck(check);
     }
 
-    private RetentionCheck imageDuplicateCheck(final OffenderNumber offenderNumber) {
+    private ActionableRetentionCheck imageDuplicateCheck(final OffenderNumber offenderNumber) {
 
         final var imageDuplicates = imageDuplicationDetectionService.findDuplicatesFor(offenderNumber);
 
-        return imageDuplicates.isEmpty() ?
+        final var check = imageDuplicates.isEmpty() ?
                 new RetentionCheckImageDuplicate(RETENTION_NOT_REQUIRED) :
                 new RetentionCheckImageDuplicate(RETENTION_REQUIRED).addImageDuplicates(imageDuplicates);
+
+        return new ActionableRetentionCheck(check);
+    }
+
+    private ActionableRetentionCheck dataDuplicateCheck(final OffenderNumber offenderNumber) {
+        return new ActionableRetentionCheck(new RetentionCheckDataDuplicate(PENDING))
+                .setPendingCheck(retentionCheck -> dataDuplicationDetectionService.searchForDuplicates(
+                        offenderNumber, retentionCheck.getRetentionCheckId()));
     }
 }

--- a/src/test/java/uk/gov/justice/hmpps/datacompliance/repository/jpa/repository/referral/OffenderDeletionReferralRepositoryTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/datacompliance/repository/jpa/repository/referral/OffenderDeletionReferralRepositoryTest.java
@@ -31,9 +31,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.justice.hmpps.datacompliance.repository.jpa.model.referral.ReferralResolution.ResolutionStatus.PENDING;
 import static uk.gov.justice.hmpps.datacompliance.repository.jpa.model.retention.RetentionCheck.Status.RETENTION_NOT_REQUIRED;
 import static uk.gov.justice.hmpps.datacompliance.repository.jpa.model.retention.RetentionCheck.Status.RETENTION_REQUIRED;
-import static uk.gov.justice.hmpps.datacompliance.repository.jpa.model.retention.RetentionCheckImageDuplicate.IMAGE_DUPLICATE;
-import static uk.gov.justice.hmpps.datacompliance.repository.jpa.model.retention.RetentionCheckManual.MANUAL_RETENTION;
-import static uk.gov.justice.hmpps.datacompliance.repository.jpa.model.retention.RetentionCheckPathfinder.PATHFINDER_REFERRAL;
 
 @ExtendWith(SpringExtension.class)
 @ActiveProfiles("test")
@@ -162,23 +159,22 @@ class OffenderDeletionReferralRepositoryTest {
 
         assertThat(retentionChecks).hasSize(3);
 
-        final var manualRetentionCheck = getRetentionCheck(retentionChecks, MANUAL_RETENTION, RetentionCheckManual.class);
+        final var manualRetentionCheck = getRetentionCheck(retentionChecks, RetentionCheckManual.class);
         assertThat(manualRetentionCheck.getCheckStatus()).isEqualTo(Status.PENDING);
         assertThat(manualRetentionCheck.getManualRetention().getManualRetentionId()).isEqualTo(1L);
 
-        final var pathfinderReferralCheck = getRetentionCheck(retentionChecks, PATHFINDER_REFERRAL, RetentionCheckPathfinder.class);
+        final var pathfinderReferralCheck = getRetentionCheck(retentionChecks, RetentionCheckPathfinder.class);
         assertThat(pathfinderReferralCheck.getCheckStatus()).isEqualTo(RETENTION_REQUIRED);
 
-        final var imageDuplicateCheck = getRetentionCheck(retentionChecks, IMAGE_DUPLICATE, RetentionCheckImageDuplicate.class);
+        final var imageDuplicateCheck = getRetentionCheck(retentionChecks, RetentionCheckImageDuplicate.class);
         assertThat(imageDuplicateCheck.getCheckStatus()).isEqualTo(RETENTION_NOT_REQUIRED);
         assertThat(imageDuplicateCheck.getImageDuplicates()).extracting(ImageDuplicate::getImageDuplicateId).containsExactly(1L);
     }
 
     private <T extends RetentionCheck> T getRetentionCheck(final List<RetentionCheck> retentionChecks,
-                                                           final String checkType,
                                                            final Class<T> retentionCheckClass) {
         return retentionChecks.stream()
-                .filter(check -> checkType.equals(check.getCheckType()))
+                .filter(retentionCheckClass::isInstance)
                 .map(retentionCheckClass::cast)
                 .findFirst()
                 .orElseThrow();

--- a/src/test/java/uk/gov/justice/hmpps/datacompliance/services/RetentionServiceTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/datacompliance/services/RetentionServiceTest.java
@@ -8,11 +8,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.justice.hmpps.datacompliance.client.pathfinder.PathfinderApiClient;
 import uk.gov.justice.hmpps.datacompliance.dto.OffenderNumber;
 import uk.gov.justice.hmpps.datacompliance.repository.jpa.model.duplication.ImageDuplicate;
+import uk.gov.justice.hmpps.datacompliance.repository.jpa.model.retention.RetentionCheckDataDuplicate;
 import uk.gov.justice.hmpps.datacompliance.repository.jpa.model.retention.RetentionCheckImageDuplicate;
 import uk.gov.justice.hmpps.datacompliance.repository.jpa.model.retention.RetentionCheckManual;
 import uk.gov.justice.hmpps.datacompliance.repository.jpa.model.retention.RetentionCheckPathfinder;
 import uk.gov.justice.hmpps.datacompliance.repository.jpa.model.retention.manual.ManualRetention;
+import uk.gov.justice.hmpps.datacompliance.services.duplicate.detection.data.DataDuplicationDetectionService;
 import uk.gov.justice.hmpps.datacompliance.services.duplicate.detection.image.ImageDuplicationDetectionService;
+import uk.gov.justice.hmpps.datacompliance.services.retention.ActionableRetentionCheck;
 import uk.gov.justice.hmpps.datacompliance.services.retention.ManualRetentionService;
 import uk.gov.justice.hmpps.datacompliance.services.retention.RetentionService;
 
@@ -21,8 +24,12 @@ import java.util.Optional;
 
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.justice.hmpps.datacompliance.repository.jpa.model.retention.RetentionCheck.Status.PENDING;
 import static uk.gov.justice.hmpps.datacompliance.repository.jpa.model.retention.RetentionCheck.Status.RETENTION_NOT_REQUIRED;
 import static uk.gov.justice.hmpps.datacompliance.repository.jpa.model.retention.RetentionCheck.Status.RETENTION_REQUIRED;
 
@@ -40,6 +47,9 @@ class RetentionServiceTest {
     @Mock
     private ImageDuplicationDetectionService imageDuplicationDetectionService;
 
+    @Mock
+    private DataDuplicationDetectionService dataDuplicationDetectionService;
+
     private RetentionService service;
 
     @BeforeEach
@@ -47,7 +57,8 @@ class RetentionServiceTest {
         service = new RetentionService(
                 pathfinderApiClient,
                 manualRetentionService,
-                imageDuplicationDetectionService);
+                imageDuplicationDetectionService,
+                dataDuplicationDetectionService);
     }
 
     @Test
@@ -61,12 +72,18 @@ class RetentionServiceTest {
                 .thenReturn(Optional.of(manualRetention));
         when(imageDuplicationDetectionService.findDuplicatesFor(OFFENDER_NUMBER)).thenReturn(List.of(imageDuplicate));
 
-        assertThat(service.conductRetentionChecks(OFFENDER_NUMBER))
+        final var retentionChecks = service.conductRetentionChecks(OFFENDER_NUMBER);
+
+        assertThat(retentionChecks).extracting(ActionableRetentionCheck::getRetentionCheck)
                 .containsExactlyInAnyOrder(
                         new RetentionCheckPathfinder(RETENTION_REQUIRED),
                         new RetentionCheckManual(RETENTION_REQUIRED).setManualRetention(manualRetention),
                         new RetentionCheckImageDuplicate(RETENTION_REQUIRED)
-                                .addImageDuplicates(List.of(imageDuplicate)));
+                                .addImageDuplicates(List.of(imageDuplicate)),
+                        new RetentionCheckDataDuplicate(PENDING));
+
+        retentionChecks.forEach(ActionableRetentionCheck::triggerPendingCheck);
+        verify(dataDuplicationDetectionService).searchForDuplicates(eq(OFFENDER_NUMBER), any());
     }
 
     @Test
@@ -76,10 +93,16 @@ class RetentionServiceTest {
         when(manualRetentionService.findManualOffenderRetentionWithReasons(OFFENDER_NUMBER)).thenReturn(Optional.empty());
         when(imageDuplicationDetectionService.findDuplicatesFor(OFFENDER_NUMBER)).thenReturn(emptyList());
 
-        assertThat(service.conductRetentionChecks(OFFENDER_NUMBER))
+        final var retentionChecks = service.conductRetentionChecks(OFFENDER_NUMBER);
+
+        assertThat(retentionChecks).extracting(ActionableRetentionCheck::getRetentionCheck)
                 .containsExactlyInAnyOrder(
                         new RetentionCheckPathfinder(RETENTION_NOT_REQUIRED),
                         new RetentionCheckManual(RETENTION_NOT_REQUIRED),
-                        new RetentionCheckImageDuplicate(RETENTION_NOT_REQUIRED));
+                        new RetentionCheckImageDuplicate(RETENTION_NOT_REQUIRED),
+                        new RetentionCheckDataDuplicate(PENDING));
+
+        retentionChecks.forEach(ActionableRetentionCheck::triggerPendingCheck);
+        verify(dataDuplicationDetectionService).searchForDuplicates(eq(OFFENDER_NUMBER), any());
     }
 }

--- a/src/test/java/uk/gov/justice/hmpps/datacompliance/services/duplicate/detection/DataDuplicationDetectionServiceTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/datacompliance/services/duplicate/detection/DataDuplicationDetectionServiceTest.java
@@ -4,8 +4,6 @@ import org.junit.jupiter.api.Test;
 import uk.gov.justice.hmpps.datacompliance.dto.OffenderNumber;
 import uk.gov.justice.hmpps.datacompliance.services.duplicate.detection.data.DataDuplicationDetectionService;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 class DataDuplicationDetectionServiceTest {
 
     private static final OffenderNumber OFFENDER_NUMBER = new OffenderNumber("A1234AA");
@@ -13,7 +11,7 @@ class DataDuplicationDetectionServiceTest {
     private DataDuplicationDetectionService service = new DataDuplicationDetectionService();
 
     @Test
-    void findDuplicatesReturnsEmpty() {
-        assertThat(service.findDuplicatesFor(OFFENDER_NUMBER)).isEmpty();
+    void searchForDuplicates() {
+        service.searchForDuplicates(OFFENDER_NUMBER, 1L);
     }
 }


### PR DESCRIPTION
The data duplication check is one of the checks that
is a long running asynchronous process so it is
initially persisted in a 'PENDING' state. The id of
the persisted check will be sent in an SQS event
to Elite2 API (future PR) for processing.