### PR TITLE
GDPR-127 Ensuring OffenderNumbers are valid

### DIFF
--- a/helm_deploy/dps-data-compliance/templates/deployment.yaml
+++ b/helm_deploy/dps-data-compliance/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /health/ping
+              path: /health/liveness
               port: {{ .Values.image.port }}
             periodSeconds: 30
             initialDelaySeconds: 90
@@ -54,7 +54,7 @@ spec:
             failureThreshold: 10
           readinessProbe:
             httpGet:
-              path: /health/ping
+              path: /health/readiness
               port: {{ .Values.image.port }}
             periodSeconds: 20
             initialDelaySeconds: 60

--- a/src/main/java/uk/gov/justice/hmpps/datacompliance/dto/OffenderNumber.java
+++ b/src/main/java/uk/gov/justice/hmpps/datacompliance/dto/OffenderNumber.java
@@ -6,6 +6,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 @Getter
@@ -14,10 +15,17 @@ import static java.util.Objects.requireNonNull;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class OffenderNumber {
 
+    private static final String OFFENDER_NUMBER_REGEX = "^[A-Z][0-9]{4}[A-Z]{2}$";
+
     private final String offenderNumber;
 
     public OffenderNumber(@JsonProperty("offenderNumber") final String offenderNumber) {
         requireNonNull(offenderNumber, "Null offender number");
+        checkArgument(isValid(offenderNumber), "Invalid offender number: '%s'", offenderNumber);
         this.offenderNumber = offenderNumber;
+    }
+
+    public static boolean isValid(final String offenderNumber) {
+        return offenderNumber.matches(OFFENDER_NUMBER_REGEX);
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -12,7 +12,8 @@ app.db.url: jdbc:hsqldb:mem:data-compliance-db;sql.syntax_pgs=true;shutdown=fals
 spring:
   flyway.locations: classpath:db/migration
   security.oauth2.resourceserver.jwt.public-key-location: classpath:local-public-key.pub
-  lifecycle.timeout-per-shutdown-phase: 0s
 
 offender.retention.ap.data.duplicate.check.enabled: true
 offender.retention.sql.data.duplicate.check.enabled: true
+
+server.shutdown: immediate

--- a/src/main/resources/application-localstack.yml
+++ b/src/main/resources/application-localstack.yml
@@ -21,7 +21,8 @@ sns:
 
 spring:
   security.oauth2.resourceserver.jwt.public-key-location: classpath:local-public-key.pub
-  lifecycle.timeout-per-shutdown-phase: 0s
 
 offender.retention.ap.data.duplicate.check.enabled: true
 offender.retention.sql.data.duplicate.check.enabled: true
+
+server.shutdown: immediate

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -55,8 +55,9 @@ server:
     context-path: /
   forward-headers-strategy: native
   tomcat:
-    remote-ip-header: x-forwarded-for
-    protocol_header: x-forwarded-proto
+    remoteip:
+      remote-ip-header: x-forwarded-for
+      protocol_header: x-forwarded-proto
 
 management:
   endpoints:
@@ -64,6 +65,9 @@ management:
       base-path: /
       exposure:
         include: 'info, health'
+  health:
+    probes:
+      enabled: true
   endpoint:
     health:
       cache:

--- a/src/test/java/uk/gov/justice/hmpps/datacompliance/client/elite2api/Elite2ApiClientTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/datacompliance/client/elite2api/Elite2ApiClientTest.java
@@ -54,8 +54,8 @@ class Elite2ApiClientTest {
     void getOffenderNumbers() throws Exception {
 
         var offenderNumbers = List.of(
-                new OffenderNumber("offender1"),
-                new OffenderNumber("offender2"));
+                new OffenderNumber("A1234AA"),
+                new OffenderNumber("B1234BB"));
 
         elite2ApiMock.enqueue(new MockResponse()
                 .setBody(OBJECT_MAPPER.writeValueAsString(offenderNumbers))
@@ -65,7 +65,7 @@ class Elite2ApiClientTest {
         var response = elite2ApiClient.getOffenderNumbers(0, PAGE_LIMIT);
 
         assertThat(response.getOffenderNumbers()).extracting(OffenderNumber::getOffenderNumber)
-                .containsExactlyInAnyOrder("offender1", "offender2");
+                .containsExactlyInAnyOrder("A1234AA", "B1234BB");
         assertThat(response.getTotalCount()).isEqualTo(123);
 
         RecordedRequest recordedRequest = elite2ApiMock.takeRequest();
@@ -106,13 +106,13 @@ class Elite2ApiClientTest {
                 .setBody(OBJECT_MAPPER.writeValueAsString(offenderImages))
                 .setHeader("Content-Type", "application/json"));
 
-        var result = elite2ApiClient.getOffenderFaceImagesFor(new OffenderNumber("offender1"));
+        var result = elite2ApiClient.getOffenderFaceImagesFor(new OffenderNumber("A1234AA"));
 
         assertThat(result).containsOnly(new OffenderImageMetadata(123L, "FACE"));
 
         RecordedRequest recordedRequest = elite2ApiMock.takeRequest();
         assertThat(recordedRequest.getMethod()).isEqualTo("GET");
-        assertThat(recordedRequest.getPath()).isEqualTo("/api/images/offenders/offender1");
+        assertThat(recordedRequest.getPath()).isEqualTo("/api/images/offenders/A1234AA");
     }
 
     @Test
@@ -120,7 +120,7 @@ class Elite2ApiClientTest {
 
         elite2ApiMock.enqueue(new MockResponse().setResponseCode(500));
 
-        assertThatThrownBy(() -> elite2ApiClient.getOffenderFaceImagesFor(new OffenderNumber("offender1")))
+        assertThatThrownBy(() -> elite2ApiClient.getOffenderFaceImagesFor(new OffenderNumber("A1234AA")))
                 .isInstanceOf(WebClientResponseException.class);
     }
 

--- a/src/test/java/uk/gov/justice/hmpps/datacompliance/client/image/recognition/AwsImageRecognitionClientTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/datacompliance/client/image/recognition/AwsImageRecognitionClientTest.java
@@ -23,7 +23,7 @@ import static uk.gov.justice.hmpps.datacompliance.client.image.recognition.Index
 class AwsImageRecognitionClientTest {
 
     private static final byte[] DATA = new byte[] { (byte) 0x01 };
-    private static final OffenderNumber OFFENDER_NUMBER = new OffenderNumber("offender1");
+    private static final OffenderNumber OFFENDER_NUMBER = new OffenderNumber("A1234AA");
     private static final long OFFENDER_IMAGE_ID = 1L;
     private static final String EXPECTED_FACE_ID = "face1";
     private static final String COLLECTION_NAME = "collection_name";

--- a/src/test/java/uk/gov/justice/hmpps/datacompliance/dto/OffenderNumberTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/datacompliance/dto/OffenderNumberTest.java
@@ -1,0 +1,39 @@
+package uk.gov.justice.hmpps.datacompliance.dto;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class OffenderNumberTest {
+
+    @Test
+    void isValid() {
+
+        assertThat(OffenderNumber.isValid("A1234AA")).isTrue();
+        assertThat(OffenderNumber.isValid("X9999YZ")).isTrue();
+
+        assertThat(OffenderNumber.isValid("A1234AAA")).isFalse();
+        assertThat(OffenderNumber.isValid("AA1234AA")).isFalse();
+        assertThat(OffenderNumber.isValid("AAAAAAA")).isFalse();
+        assertThat(OffenderNumber.isValid("1234567")).isFalse();
+        assertThat(OffenderNumber.isValid("INVALID")).isFalse();
+        assertThat(OffenderNumber.isValid(",")).isFalse();
+    }
+
+    @Test
+    void cannotCreateWithNullString() {
+
+        assertThatThrownBy(() -> new OffenderNumber(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("Null offender number");
+    }
+
+    @Test
+    void cannotCreateWithInvalidId() {
+
+        assertThatThrownBy(() -> new OffenderNumber("invalid"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Invalid offender number: 'invalid'");
+    }
+}

--- a/src/test/java/uk/gov/justice/hmpps/datacompliance/events/publishers/deletion/granted/DataComplianceEventPusherTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/datacompliance/events/publishers/deletion/granted/DataComplianceEventPusherTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.when;
 class DataComplianceEventPusherTest {
 
     private final static ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    private final static OffenderNumber OFFENDER_NUMBER = new OffenderNumber("offender1");
+    private final static OffenderNumber OFFENDER_NUMBER = new OffenderNumber("A1234AA");
 
     @Mock
     private AmazonSQS client;
@@ -44,7 +44,7 @@ class DataComplianceEventPusherTest {
         eventPusher.grantDeletion(OFFENDER_NUMBER, 123L);
 
         assertThat(request.getValue().getQueueUrl()).isEqualTo("queue.url");
-        assertThat(request.getValue().getMessageBody()).isEqualTo("{\"offenderIdDisplay\":\"offender1\",\"referralId\":123}");
+        assertThat(request.getValue().getMessageBody()).isEqualTo("{\"offenderIdDisplay\":\"A1234AA\",\"referralId\":123}");
         assertThat(request.getValue().getMessageAttributes().get("eventType").getStringValue())
                 .isEqualTo("DATA_COMPLIANCE_OFFENDER-DELETION-GRANTED");
     }
@@ -60,7 +60,7 @@ class DataComplianceEventPusherTest {
         eventPusher.requestDataDuplicateCheck(OFFENDER_NUMBER, 123L);
 
         assertThat(request.getValue().getQueueUrl()).isEqualTo("queue.url");
-        assertThat(request.getValue().getMessageBody()).isEqualTo("{\"offenderIdDisplay\":\"offender1\",\"retentionCheckId\":123}");
+        assertThat(request.getValue().getMessageBody()).isEqualTo("{\"offenderIdDisplay\":\"A1234AA\",\"retentionCheckId\":123}");
         assertThat(request.getValue().getMessageAttributes().get("eventType").getStringValue())
                 .isEqualTo("DATA_COMPLIANCE_DATA-DUPLICATE-CHECK");
     }

--- a/src/test/java/uk/gov/justice/hmpps/datacompliance/jobs/imageupload/OffenderImageUploadLoggerTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/datacompliance/jobs/imageupload/OffenderImageUploadLoggerTest.java
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.*;
 class OffenderImageUploadLoggerTest {
 
     private static final LocalDateTime DATE_TIME = LocalDateTime.now();
-    private static final String OFFENDER_NUMBER = "offender1";
+    private static final String OFFENDER_NUMBER = "A1234AA";
     private static final FaceId FACE_ID = new FaceId("face1");
     private static final long IMAGE_ID = 123L;
 

--- a/src/test/java/uk/gov/justice/hmpps/datacompliance/jobs/imageupload/OffenderImageUploaderTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/datacompliance/jobs/imageupload/OffenderImageUploaderTest.java
@@ -24,7 +24,7 @@ import static uk.gov.justice.hmpps.datacompliance.utils.Result.success;
 @ExtendWith(MockitoExtension.class)
 class OffenderImageUploaderTest {
 
-    private static final OffenderNumber OFFENDER_NUMBER = new OffenderNumber("offender1");
+    private static final OffenderNumber OFFENDER_NUMBER = new OffenderNumber("A1234AA");
     private static final long IMAGE_ID = 123L;
     private static final byte[] IMAGE_DATA = new byte[]{0x12};
     private static final OffenderImageMetadata IMAGE_METADATA = new OffenderImageMetadata(IMAGE_ID, "FACE");

--- a/src/test/java/uk/gov/justice/hmpps/datacompliance/jobs/imageupload/OffenderIteratorTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/datacompliance/jobs/imageupload/OffenderIteratorTest.java
@@ -30,6 +30,10 @@ import static org.mockito.Mockito.lenient;
 @ExtendWith(MockitoExtension.class)
 class OffenderIteratorTest {
 
+    private static final String OFFENDER_1 = "A1234AA";
+    private static final String OFFENDER_2 = "B1234BB";
+    private static final String OFFENDER_3 = "C1234CC";
+    private static final String OFFENDER_4 = "D1234DD";
     private static final int REQUEST_LIMIT = 2;
     private static final DataComplianceProperties PROPERTIES = DataComplianceProperties.builder()
             .elite2ApiBaseUrl("some-url")
@@ -56,20 +60,20 @@ class OffenderIteratorTest {
 
     @Test
     void applyForAllHandlesCountLessThanRequestLimit() {
-        mockOffenderNumbersResponse("offender1");
-        assertThat(processedOffenderNumbers()).containsExactlyInAnyOrder("offender1");
+        mockOffenderNumbersResponse(OFFENDER_1);
+        assertThat(processedOffenderNumbers()).containsExactlyInAnyOrder(OFFENDER_1);
     }
 
     @Test
     void applyForAllHandlesCountEqualToRequestLimit() {
-        mockOffenderNumbersResponse("offender1", "offender2");
-        assertThat(processedOffenderNumbers()).containsExactlyInAnyOrder("offender1", "offender2");
+        mockOffenderNumbersResponse(OFFENDER_1, OFFENDER_2);
+        assertThat(processedOffenderNumbers()).containsExactlyInAnyOrder(OFFENDER_1, OFFENDER_2);
     }
 
     @Test
     void applyForAllHandlesCountGreaterThanRequestLimit() {
-        mockOffenderNumbersResponse("offender1", "offender2", "offender3");
-        assertThat(processedOffenderNumbers()).containsExactlyInAnyOrder("offender1", "offender2", "offender3");
+        mockOffenderNumbersResponse(OFFENDER_1, OFFENDER_2, OFFENDER_3);
+        assertThat(processedOffenderNumbers()).containsExactlyInAnyOrder(OFFENDER_1, OFFENDER_2, OFFENDER_3);
     }
 
     @Test
@@ -80,14 +84,14 @@ class OffenderIteratorTest {
                         .waitDuration(Duration.ZERO)
                         .build());
 
-        mockOffenderNumbersResponse("offender1", "offender2", "offender3");
+        mockOffenderNumbersResponse(OFFENDER_1, OFFENDER_2, OFFENDER_3);
 
         final var processedOffenderNumbers = new ArrayList<String>();
 
         offenderIterator.applyForAll(throwOnFirstAttempt(
                 offenderNumber -> processedOffenderNumbers.add(offenderNumber.getOffenderNumber())));
 
-        assertThat(processedOffenderNumbers).containsExactlyInAnyOrder("offender1", "offender2", "offender3");
+        assertThat(processedOffenderNumbers).containsExactlyInAnyOrder(OFFENDER_1, OFFENDER_2, OFFENDER_3);
     }
 
     @Test
@@ -96,14 +100,14 @@ class OffenderIteratorTest {
         offenderIterator = new OffenderIterator(client, PROPERTIES,
                 RetryConfig.custom().maxAttempts(1).build());
 
-        mockOffenderNumbersResponse("offender1", "offender2", "offender3");
+        mockOffenderNumbersResponse(OFFENDER_1, OFFENDER_2, OFFENDER_3);
 
         final var processedOffenderNumbers = new ArrayList<String>();
         assertThatThrownBy(() -> offenderIterator.applyForAll(throwOnFirstAttempt(
                 offenderNumber -> processedOffenderNumbers.add(offenderNumber.getOffenderNumber()))))
                 .hasMessageContaining("Failed!");
 
-        assertThat(processedOffenderNumbers).doesNotContain("offender3");
+        assertThat(processedOffenderNumbers).doesNotContain(OFFENDER_3);
     }
 
     @Test
@@ -117,9 +121,9 @@ class OffenderIteratorTest {
                         .elite2ApiOffenderIdsTotalPages(1L)
                         .build());
 
-        mockOffenderNumbersResponseWithOffset(1, "offender1", "offender2", "offender3", "offender4");
+        mockOffenderNumbersResponseWithOffset(1, OFFENDER_1, OFFENDER_2, OFFENDER_3, OFFENDER_4);
 
-        assertThat(processedOffenderNumbers()).containsOnly("offender2", "offender3");
+        assertThat(processedOffenderNumbers()).containsOnly(OFFENDER_2, OFFENDER_3);
 
     }
 

--- a/src/test/java/uk/gov/justice/hmpps/datacompliance/services/duplicate/detection/ImageDuplicationDetectionServiceTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/datacompliance/services/duplicate/detection/ImageDuplicationDetectionServiceTest.java
@@ -20,6 +20,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import static java.lang.String.format;
 import static java.util.Arrays.stream;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toSet;
@@ -177,7 +178,7 @@ class ImageDuplicationDetectionServiceTest {
         return new FaceId("face" + suffix);
     }
 
-    private OffenderNumber offenderNo(final long suffix) {
-        return new OffenderNumber("offender" + suffix);
+    private OffenderNumber offenderNo(final long index) {
+        return new OffenderNumber(format("A%04dAA", index));
     }
 }


### PR DESCRIPTION
As part of my AWS Athena integration with
Analytical Platform, I want to ensure that the
offender number I enter into the query is valid
(does not pose a SQL injection risk since the
Athena SDK doesn't support prepared statements).

Since all offender numbers in production and all
but one in T3 match the regex, it seems prudent
to only pass around valid offender numbers in the
system.