### PR TITLE
GDPR-70 Echoing back offender ids to verify at point of deletion.

### DIFF
--- a/readme/deletion_events.md
+++ b/readme/deletion_events.md
@@ -41,12 +41,13 @@ are copied into an auto-execution directory in the container.
 
 The following command can be run after the docker containers have started up
 in order to simulate a deletion (replacing `SOME_OFFENDER_ID_DISPLAY` with a
-valid offender number, and using an existing offender referral id):
+valid offender number, using an existing offender referral id, and providing
+all the offender's offender ids and booking ids):
 
 ```bash
 aws --endpoint-url=http://localhost:4576 sqs send-message \
     --queue-url http://localstack:4576/queue/data_compliance_request_queue \
-    --message-body '{"offenderIdDisplay":"SOME_OFFENDER_ID_DISPLAY","referralId":1}' \
+    --message-body '{"offenderIdDisplay":"SOME_OFFENDER_ID_DISPLAY","referralId":1,"offenderIds":[123],"offenderBookIds":[456]}' \
     --message-attributes "eventType={StringValue=DATA_COMPLIANCE_OFFENDER-DELETION-GRANTED,DataType=String}"
 ```
 

--- a/readme/overview.md
+++ b/readme/overview.md
@@ -3,15 +3,17 @@
 ## Overview
 
 The DPS Data Compliance Service is responsible for periodically
-checking NOMIS offender records to ensure they comply with data 
+checking NOMIS offender records to ensure they comply with data
 protection laws.
 
 The high-level strategy is as follows:
 
-1. Identify offender records due for deletion in line with 
-the Ministry of Justice Records, Information Management and 
+1. Identify offender records due for deletion in line with
+the Ministry of Justice Records, Information Management and
 Retention Policy.
-2. Ensure that there are no potential duplicate, unmerged
+2. Check to ensure the record has not been manually marked
+for retention by prison staff.
+3. Ensure that there are no potential duplicate, unmerged
 records in the database.
-3. Automatically retain records where the data must be legally
+4. Automatically retain records where the data must be legally
 retained due to moratoria.

--- a/readme/running.md
+++ b/readme/running.md
@@ -67,7 +67,11 @@ to start up:
 
 - `ELITE2_API_BASE_URL` (URL for the Elite2 API)
 - `OAUTH2_API_BASE_URL` (URL for the OAuth2 server)
+- `PATHFINDER_API_BASE_URL` (URL for the Pathfinder API)
 - `APP_DB_URL` (URL for a database instance to store data compliance data)
+- `OFFENDER_RETENTION_DATA_DUPLICATE_ID_CHECK_ENABLED` (Flag to use Elite2 API to perform a duplicate ID check)
+- `OFFENDER_RETENTION_DATA_DUPLICATE_DB_CHECK_ENABLED` (Flag to use Elite2 API to perform a duplicate check using data in the database.)
+- `OFFENDER_RETENTION_DATA_DUPLICATE_AP_CHECK_ENABLED` (Flag to query Analytical Platform for potential duplicates.)
 
 These are provided already if running with the `dev` Spring profile (see the `application-dev.yml` properties file).
 

--- a/src/main/java/uk/gov/justice/hmpps/datacompliance/dto/OffenderDeletionGrant.java
+++ b/src/main/java/uk/gov/justice/hmpps/datacompliance/dto/OffenderDeletionGrant.java
@@ -6,13 +6,15 @@ import lombok.Getter;
 import lombok.Singular;
 import lombok.ToString;
 
-import java.util.List;
+import java.util.Set;
 
 @Getter
 @Builder
 @ToString
 @EqualsAndHashCode
-public class OffenderToCheck {
+public class OffenderDeletionGrant {
     private final OffenderNumber offenderNumber;
-    @Singular private final List<String> offenceCodes;
+    private final Long referralId;
+    @Singular private final Set<Long> offenderIds;
+    @Singular private final Set<Long> offenderBookIds;
 }

--- a/src/main/java/uk/gov/justice/hmpps/datacompliance/events/publishers/dto/OffenderDeletionGranted.java
+++ b/src/main/java/uk/gov/justice/hmpps/datacompliance/events/publishers/dto/OffenderDeletionGranted.java
@@ -3,12 +3,17 @@ package uk.gov.justice.hmpps.datacompliance.events.publishers.dto;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.Singular;
+
+import java.util.Set;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 @Data
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonInclude(NON_NULL)
@@ -19,5 +24,13 @@ public class OffenderDeletionGranted {
 
     @JsonProperty("referralId")
     private Long referralId;
+
+    @Singular
+    @JsonProperty("offenderIds")
+    private Set<Long> offenderIds;
+
+    @Singular
+    @JsonProperty("offenderBookIds")
+    private Set<Long> offenderBookIds;
 }
 

--- a/src/main/java/uk/gov/justice/hmpps/datacompliance/events/publishers/sqs/DataComplianceAwsEventPusher.java
+++ b/src/main/java/uk/gov/justice/hmpps/datacompliance/events/publishers/sqs/DataComplianceAwsEventPusher.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.stereotype.Component;
+import uk.gov.justice.hmpps.datacompliance.dto.OffenderDeletionGrant;
 import uk.gov.justice.hmpps.datacompliance.dto.OffenderNumber;
 import uk.gov.justice.hmpps.datacompliance.events.publishers.dto.DataDuplicateCheck;
 import uk.gov.justice.hmpps.datacompliance.events.publishers.dto.FreeTextSearchRequest;
@@ -45,12 +46,17 @@ public class DataComplianceAwsEventPusher implements DataComplianceEventPusher {
     }
 
     @Override
-    public void grantDeletion(final OffenderNumber offenderNo, final Long referralId) {
+    public void grantDeletion(final OffenderDeletionGrant offenderDeletionGrant) {
 
-        log.debug("Sending grant deletion event for: '{}/{}'", offenderNo.getOffenderNumber(), referralId);
+        log.debug("Sending grant deletion event for: '{}/{}'",
+                offenderDeletionGrant.getOffenderNumber().getOffenderNumber(), offenderDeletionGrant.getReferralId());
 
-        sqsClient.sendMessage(generateRequest(OFFENDER_DELETION_GRANTED,
-                new OffenderDeletionGranted(offenderNo.getOffenderNumber(), referralId)));
+        sqsClient.sendMessage(generateRequest(OFFENDER_DELETION_GRANTED, OffenderDeletionGranted.builder()
+                .offenderIdDisplay(offenderDeletionGrant.getOffenderNumber().getOffenderNumber())
+                .referralId(offenderDeletionGrant.getReferralId())
+                .offenderIds(offenderDeletionGrant.getOffenderIds())
+                .offenderBookIds(offenderDeletionGrant.getOffenderBookIds())
+                .build()));
     }
 
     @Override

--- a/src/main/java/uk/gov/justice/hmpps/datacompliance/events/publishers/sqs/DataComplianceEventPusher.java
+++ b/src/main/java/uk/gov/justice/hmpps/datacompliance/events/publishers/sqs/DataComplianceEventPusher.java
@@ -1,11 +1,12 @@
 package uk.gov.justice.hmpps.datacompliance.events.publishers.sqs;
 
+import uk.gov.justice.hmpps.datacompliance.dto.OffenderDeletionGrant;
 import uk.gov.justice.hmpps.datacompliance.dto.OffenderNumber;
 
 import java.util.List;
 
 public interface DataComplianceEventPusher {
-    void grantDeletion(OffenderNumber offenderNumber, Long referralId);
+    void grantDeletion(OffenderDeletionGrant offenderDeletionGrant);
     void requestIdDataDuplicateCheck(OffenderNumber offenderNumber, Long retentionCheckId);
     void requestDatabaseDataDuplicateCheck(OffenderNumber offenderNumber, Long retentionCheckId);
     void requestFreeTextMoratoriumCheck(OffenderNumber offenderNumber, Long retentionCheckId, List<String> regex);

--- a/src/main/java/uk/gov/justice/hmpps/datacompliance/events/publishers/sqs/DataComplianceNoOpEventPusher.java
+++ b/src/main/java/uk/gov/justice/hmpps/datacompliance/events/publishers/sqs/DataComplianceNoOpEventPusher.java
@@ -3,6 +3,7 @@ package uk.gov.justice.hmpps.datacompliance.events.publishers.sqs;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.stereotype.Component;
+import uk.gov.justice.hmpps.datacompliance.dto.OffenderDeletionGrant;
 import uk.gov.justice.hmpps.datacompliance.dto.OffenderNumber;
 
 import java.util.List;
@@ -17,9 +18,9 @@ public class DataComplianceNoOpEventPusher implements DataComplianceEventPusher 
     }
 
     @Override
-    public void grantDeletion(final OffenderNumber offenderNo, final Long referralId) {
+    public void grantDeletion(final OffenderDeletionGrant offenderDeletionGrant) {
         log.warn("Pretending to push offender deletion granted events for '{}/{}' to queue",
-                offenderNo.getOffenderNumber(), referralId);
+                offenderDeletionGrant.getOffenderNumber().getOffenderNumber(), offenderDeletionGrant.getReferralId());
     }
 
     @Override

--- a/src/main/java/uk/gov/justice/hmpps/datacompliance/repository/jpa/model/referral/OffenderDeletionReferral.java
+++ b/src/main/java/uk/gov/justice/hmpps/datacompliance/repository/jpa/model/referral/OffenderDeletionReferral.java
@@ -96,9 +96,10 @@ public class OffenderDeletionReferral implements OffenderEntity {
     @OneToOne(mappedBy = "offenderDeletionReferral", cascade = PERSIST, fetch = LAZY)
     private ReferralResolution referralResolution;
 
-    public void addReferredOffenderBooking(final ReferredOffenderBooking booking) {
+    public OffenderDeletionReferral addReferredOffenderBooking(final ReferredOffenderBooking booking) {
         this.offenderBookings.add(booking);
         booking.setOffenderDeletionReferral(this);
+        return this;
     }
 
     public Optional<ReferralResolution> getReferralResolution() {

--- a/src/main/java/uk/gov/justice/hmpps/datacompliance/services/retention/MoratoriumCheckService.java
+++ b/src/main/java/uk/gov/justice/hmpps/datacompliance/services/retention/MoratoriumCheckService.java
@@ -34,7 +34,7 @@ public class MoratoriumCheckService {
             "faith|" +
             "foster|" +
             "girl|" +
-            "grandson" +
+            "grandson|" +
             "infant|" +
             "juven|" +
             "kid|" +


### PR DESCRIPTION
Since the retention checks can take a while to process, we need
to mitigate the risk that a new offender alias or booking has
been created between the referral of the offender and the
moment of deletion.