### PR TITLE
GDPR-157 Adapting image upload process to request offenders with new images

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/datacompliance/client/prisonapi/dto/OffendersWithImagesResponse.java
+++ b/src/main/java/uk/gov/justice/hmpps/datacompliance/client/prisonapi/dto/OffendersWithImagesResponse.java
@@ -1,0 +1,31 @@
+package uk.gov.justice.hmpps.datacompliance.client.prisonapi.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Singular;
+import lombok.ToString;
+import uk.gov.justice.hmpps.datacompliance.dto.OffenderNumber;
+
+import java.util.List;
+
+@Getter
+@Builder
+@ToString
+@EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class OffendersWithImagesResponse {
+
+    @Singular
+    @JsonProperty("content")
+    private List<OffenderNumber> offenderNumbers;
+
+    @JsonProperty("totalElements")
+    private Long totalElements;
+}

--- a/src/main/java/uk/gov/justice/hmpps/datacompliance/jobs/imageupload/OffenderImageMigration.java
+++ b/src/main/java/uk/gov/justice/hmpps/datacompliance/jobs/imageupload/OffenderImageMigration.java
@@ -26,7 +26,7 @@ class OffenderImageMigration {
         final var batch = repository.save(newUploadBatch());
         final var imageUploader = uploaderFactory.generateUploaderFor(batch);
 
-        offenderIterator.applyForAll(imageUploader);
+        offenderIterator.applyForAll(batch, imageUploader);
 
         batch.setUploadEndDateTime(timeSource.nowAsLocalDateTime());
         batch.setUploadCount(imageUploader.getUploadCount());

--- a/src/main/java/uk/gov/justice/hmpps/datacompliance/jobs/imageupload/OffenderImageUploader.java
+++ b/src/main/java/uk/gov/justice/hmpps/datacompliance/jobs/imageupload/OffenderImageUploader.java
@@ -33,14 +33,16 @@ class OffenderImageUploader implements OffenderAction {
             return;
         }
 
-        faceImages.forEach(image -> getAndUploadImageData(image, offenderNumber));
+        faceImages.stream()
+                .filter(image -> !uploadLogger.isAlreadyUploaded(offenderNumber, image.getImageId()))
+                .forEach(image -> getAndUploadImageData(offenderNumber, image));
     }
 
     long getUploadCount() {
         return uploadLogger.getUploadCount();
     }
 
-    private void getAndUploadImageData(final OffenderImageMetadata imageMetadata, final OffenderNumber offenderNumber) {
+    private void getAndUploadImageData(final OffenderNumber offenderNumber, final OffenderImageMetadata imageMetadata) {
 
         log.trace("Uploading image: '{}' for offender: '{}'", imageMetadata.getImageId(), offenderNumber.getOffenderNumber());
 

--- a/src/main/java/uk/gov/justice/hmpps/datacompliance/jobs/imageupload/OffenderIterator.java
+++ b/src/main/java/uk/gov/justice/hmpps/datacompliance/jobs/imageupload/OffenderIterator.java
@@ -6,10 +6,12 @@ import io.github.resilience4j.retry.RetryConfig;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import uk.gov.justice.hmpps.datacompliance.config.DataComplianceProperties;
-import uk.gov.justice.hmpps.datacompliance.dto.OffenderNumber;
 import uk.gov.justice.hmpps.datacompliance.client.prisonapi.PrisonApiClient;
 import uk.gov.justice.hmpps.datacompliance.client.prisonapi.PrisonApiClient.OffenderNumbersResponse;
+import uk.gov.justice.hmpps.datacompliance.config.DataComplianceProperties;
+import uk.gov.justice.hmpps.datacompliance.dto.OffenderNumber;
+import uk.gov.justice.hmpps.datacompliance.repository.jpa.model.duplication.ImageUploadBatch;
+import uk.gov.justice.hmpps.datacompliance.repository.jpa.repository.duplication.ImageUploadBatchRepository;
 
 import java.time.Duration;
 import java.util.concurrent.Callable;
@@ -36,52 +38,58 @@ class OffenderIterator {
     private static final Duration UPLOAD_RETRY_INITIAL_INTERVAL = Duration.ofMillis(500);
     private static final double UPLOAD_RETRY_MULTIPLIER = 2;
 
+    private final ImageUploadBatchRepository repository;
     private final PrisonApiClient prisonApiClient;
     private final DataComplianceProperties properties;
     private final ExecutorService executorService;
     private final RetryConfig retryConfig;
 
     @Autowired
-    public OffenderIterator(final PrisonApiClient prisonApiClient,
+    public OffenderIterator(final ImageUploadBatchRepository repository,
+                            final PrisonApiClient prisonApiClient,
                             final DataComplianceProperties properties) {
-        this(prisonApiClient, properties, custom()
+        this(repository, prisonApiClient, properties, custom()
                 .maxAttempts(UPLOAD_RETRY_MAX_ATTEMPTS)
                 .intervalFunction(ofExponentialBackoff(UPLOAD_RETRY_INITIAL_INTERVAL, UPLOAD_RETRY_MULTIPLIER))
                 .build());
     }
 
     @VisibleForTesting
-    OffenderIterator(final PrisonApiClient prisonApiClient,
+    OffenderIterator(final ImageUploadBatchRepository repository,
+                     final PrisonApiClient prisonApiClient,
                      final DataComplianceProperties properties,
                      final RetryConfig retryConfig) {
+        this.repository = repository;
         this.executorService = newFixedThreadPool(properties.getPrisonApiOffenderIdsIterationThreads());
         this.prisonApiClient = prisonApiClient;
         this.properties = properties;
         this.retryConfig = retryConfig;
     }
 
-    void applyForAll(final OffenderAction action) {
+    void applyForAll(final ImageUploadBatch batch, final OffenderAction action) {
 
-        log.info("Applying offender action to first batch of up to {} offenders, offset: {}",
+        log.info("Applying offender action to first page of up to {} offenders, offset: {}",
                 pageLimit(), properties.getPrisonApiOffenderIdsInitialOffset());
-        final var firstBatchResponse = applyForBatch(action, 0);
+        final var firstPageResponse = applyForPage(0, action, batch);
 
-        log.info("Total number of {} offenders", firstBatchResponse.getTotalCount());
+        log.info("Total number of {} offenders", firstPageResponse.getTotalCount());
         properties.getOffenderIdsTotalPages()
                 .ifPresent(total -> log.info("Limiting iteration to {} pages of data", total));
 
-        LongStream.rangeClosed(1, indexOfFinalBatch(firstBatchResponse))
-                .forEach(batchIndex -> applyForBatch(action, batchIndex));
+        LongStream.rangeClosed(1, indexOfFinalPage(firstPageResponse))
+                .forEach(pageNumber -> applyForPage(pageNumber, action, batch));
 
         log.info("Offender action applied");
     }
 
-    private OffenderNumbersResponse applyForBatch(final OffenderAction action, final long batchIndex) {
+    private OffenderNumbersResponse applyForPage(final long pageNumber,
+                                                 final OffenderAction action,
+                                                 final ImageUploadBatch batch) {
 
-        log.info("Applying offender action to batch {}", batchIndex);
+        log.info("Applying offender action to page {}", pageNumber);
 
-        final var offset = properties.getPrisonApiOffenderIdsInitialOffset() + (batchIndex * pageLimit());
-        final var response = prisonApiClient.getOffenderNumbers(offset, pageLimit());
+        final var offset = properties.getPrisonApiOffenderIdsInitialOffset() + (pageNumber * pageLimit());
+        final var response = getOffenderNumbers(offset, pageLimit(), batch);
         final var tasks = response.getOffenderNumbers().stream()
                 .map(offenderNumber -> applyWithRetry(action, offenderNumber))
                 .collect(toList());
@@ -95,13 +103,23 @@ class OffenderIterator {
 
             currentThread().interrupt();
 
-            throw new IllegalStateException("Execution of batch interrupted", e);
+            throw new IllegalStateException("Execution interrupted", e);
         }
 
         return response;
     }
 
-    private long indexOfFinalBatch(final OffenderNumbersResponse response) {
+    private OffenderNumbersResponse getOffenderNumbers(final long offset,
+                                                       final long limit,
+                                                       final ImageUploadBatch batch) {
+
+        return repository.findFirstByBatchIdNotOrderByUploadStartDateTimeDesc(batch.getBatchId())
+                .map(lastUpload -> prisonApiClient.getOffendersWithNewImages(
+                        lastUpload.getUploadStartDateTime().toLocalDate(), offset, limit))
+                .orElseGet(() -> prisonApiClient.getOffenderNumbers(offset, limit));
+    }
+
+    private long indexOfFinalPage(final OffenderNumbersResponse response) {
 
         final var totalBatches = (long) ceil((double) response.getTotalCount() / pageLimit());
 

--- a/src/main/java/uk/gov/justice/hmpps/datacompliance/repository/jpa/repository/duplication/ImageUploadBatchRepository.java
+++ b/src/main/java/uk/gov/justice/hmpps/datacompliance/repository/jpa/repository/duplication/ImageUploadBatchRepository.java
@@ -4,6 +4,9 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 import uk.gov.justice.hmpps.datacompliance.repository.jpa.model.duplication.ImageUploadBatch;
 
+import java.util.Optional;
+
 @Repository
 public interface ImageUploadBatchRepository extends CrudRepository<ImageUploadBatch, Long> {
+    Optional<ImageUploadBatch> findFirstByBatchIdNotOrderByUploadStartDateTimeDesc(final long batchId);
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -5,6 +5,7 @@ pathfinder.api.base.url: http://localhost:8083
 app.db.url: jdbc:hsqldb:mem:data-compliance-db;sql.syntax_pgs=true;shutdown=false
 
 spring:
+  jpa.show-sql: true
   flyway.locations: classpath:db/migration
   security.oauth2.resourceserver.jwt.public-key-location: classpath:local-public-key.pub
 

--- a/src/test/java/uk/gov/justice/hmpps/datacompliance/jobs/imageupload/OffenderImageUploadLoggerTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/datacompliance/jobs/imageupload/OffenderImageUploadLoggerTest.java
@@ -15,14 +15,9 @@ import uk.gov.justice.hmpps.datacompliance.repository.jpa.repository.duplication
 import uk.gov.justice.hmpps.datacompliance.utils.TimeSource;
 
 import java.time.LocalDateTime;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class OffenderImageUploadLoggerTest {
@@ -50,8 +45,6 @@ class OffenderImageUploadLoggerTest {
 
         assertThat(logger.getUploadCount()).isZero();
 
-        when(repository.findByOffenderNoAndImageId(any(), any())).thenReturn(Optional.empty());
-
         logger.log(
                 OffenderImage.builder()
                         .offenderNumber(new OffenderNumber(OFFENDER_NUMBER))
@@ -74,30 +67,10 @@ class OffenderImageUploadLoggerTest {
     }
 
     @Test
-    void doesNotPersistUploadIfAlreadyExists() {
-
-        assertThat(logger.getUploadCount()).isZero();
-
-        when(repository.findByOffenderNoAndImageId(OFFENDER_NUMBER, IMAGE_ID))
-                .thenReturn(Optional.of(mock(OffenderImageUpload.class)));
-
-        logger.log(
-                OffenderImage.builder()
-                        .offenderNumber(new OffenderNumber(OFFENDER_NUMBER))
-                        .imageId(IMAGE_ID)
-                        .build(),
-                FACE_ID);
-        
-        verify(repository, never()).save(any());
-        assertThat(logger.getUploadCount()).isZero();
-    }
-
-    @Test
     void logUploadError() {
 
         assertThat(logger.getUploadCount()).isZero();
 
-        when(repository.findByOffenderNoAndImageId(any(), any())).thenReturn(Optional.empty());
         logger.logUploadError(new OffenderNumber(OFFENDER_NUMBER), IMAGE_ID, "some reason");
 
         var offenderImageUpload = ArgumentCaptor.forClass(OffenderImageUpload.class);

--- a/src/test/java/uk/gov/justice/hmpps/datacompliance/repository/jpa/repository/duplication/ImageUploadBatchRepositoryTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/datacompliance/repository/jpa/repository/duplication/ImageUploadBatchRepositoryTest.java
@@ -70,4 +70,10 @@ class ImageUploadBatchRepositoryTest {
         assertThat(retrievedEntity.getUploadCount()).isEqualTo(123L);
         assertThat(retrievedEntity.getUploadEndDateTime()).isEqualTo(DATE_TIME.plusSeconds(1));
     }
+
+    @Test
+    @Sql(value = "image_upload_batch.sql")
+    void findLatestUploadBatch() {
+        assertThat(repository.findFirstByBatchIdNotOrderByUploadStartDateTimeDesc(3).get().getBatchId()).isEqualTo(2);
+    }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -10,7 +10,9 @@ pathfinder.api.base.url: http://localhost:8997
 app.db.url: jdbc:hsqldb:mem:data-compliance-db;sql.syntax_pgs=true;shutdown=false
 
 spring:
-  jpa.hibernate.ddl-auto: create-drop
+  jpa:
+    show-sql: true
+    hibernate.ddl-auto: create-drop
   flyway.locations: classpath:db/migration
   security.oauth2.resourceserver.jwt.public-key-location: classpath:local-public-key.pub
   lifecycle.timeout-per-shutdown-phase: 0s

--- a/src/test/resources/uk/gov/justice/hmpps/datacompliance/jobs/imageupload/image_upload_batch.sql
+++ b/src/test/resources/uk/gov/justice/hmpps/datacompliance/jobs/imageupload/image_upload_batch.sql
@@ -1,0 +1,1 @@
+INSERT INTO image_upload_batch (batch_id, upload_start_date_time) VALUES (1, to_timestamp('2020-01-01 01:02:03', 'YYYY-MM-DD HH:MI:SS'));

--- a/src/test/resources/uk/gov/justice/hmpps/datacompliance/repository/jpa/repository/duplication/image_upload_batch.sql
+++ b/src/test/resources/uk/gov/justice/hmpps/datacompliance/repository/jpa/repository/duplication/image_upload_batch.sql
@@ -1,1 +1,3 @@
 INSERT INTO image_upload_batch (batch_id, upload_start_date_time) VALUES (1, to_timestamp('2020-01-01 01:02:03', 'YYYY-MM-DD HH:MI:SS'));
+INSERT INTO image_upload_batch (batch_id, upload_start_date_time) VALUES (2, to_timestamp('2021-01-01 01:02:03', 'YYYY-MM-DD HH:MI:SS'));
+INSERT INTO image_upload_batch (batch_id, upload_start_date_time) VALUES (3, to_timestamp('2022-01-01 01:02:03', 'YYYY-MM-DD HH:MI:SS'));


### PR DESCRIPTION
After the initial upload has been run, the process should now
request only offenders with images captured after the last time
the process ran to keep the image collection up to date.