### PR TITLE
GDPR-343: revert to v1beta1 apiversion as from CronJob

### DIFF
--- a/helm_deploy/dps-data-compliance/templates/housekeeping-cronjob.yaml
+++ b/helm_deploy/dps-data-compliance/templates/housekeeping-cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1 CronJob
+apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: {{ include "app.fullname" . }}-queue-housekeeping-cronjob


### PR DESCRIPTION
Reverting as CronJob is unavailable