### PR TITLE
GDPR-353:🐛 Correct singular 'restrictonCode' to its plural 'restrictionCodes'

### DIFF
--- a/src/main/java/uk/gov/justice/hmpps/datacompliance/events/publishers/dto/OffenderRestrictionRequest.java
+++ b/src/main/java/uk/gov/justice/hmpps/datacompliance/events/publishers/dto/OffenderRestrictionRequest.java
@@ -24,7 +24,7 @@ public class OffenderRestrictionRequest {
     private Long retentionCheckId;
 
     @Singular
-    @JsonProperty("restrictionCode")
+    @JsonProperty("restrictionCodes")
     private Set<OffenderRestrictionCode> restrictionCodes;
 
     @JsonProperty("regex")

--- a/src/test/java/uk/gov/justice/hmpps/datacompliance/events/publishers/deletion/sqs/DataComplianceAwsEventPusherTest.java
+++ b/src/test/java/uk/gov/justice/hmpps/datacompliance/events/publishers/deletion/sqs/DataComplianceAwsEventPusherTest.java
@@ -204,7 +204,7 @@ class DataComplianceAwsEventPusherTest {
         eventPusher.requestOffenderRestrictionCheck(OFFENDER_NUMBER, 123L, Set.of(CHILD), "^(regex|1)$");
 
         assertThat(request.getValue().getQueueUrl()).isEqualTo("queue.url");
-        assertThat(request.getValue().getMessageBody()).isEqualTo("{\"offenderIdDisplay\":\"A1234AA\",\"retentionCheckId\":123,\"restrictionCode\":[\"CHILD\"],\"regex\":\"^(regex|1)$\"}");
+        assertThat(request.getValue().getMessageBody()).isEqualTo("{\"offenderIdDisplay\":\"A1234AA\",\"retentionCheckId\":123,\"restrictionCodes\":[\"CHILD\"],\"regex\":\"^(regex|1)$\"}");
         assertThat(request.getValue().getMessageAttributes().get("eventType").getStringValue())
             .isEqualTo("DATA_COMPLIANCE_OFFENDER-RESTRICTION-CHECK");
     }


### PR DESCRIPTION
…onCodes'